### PR TITLE
MOSIP-28216

### DIFF
--- a/registration/registration-services/src/main/java/io/mosip/registration/util/acktemplate/TemplateGenerator.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/util/acktemplate/TemplateGenerator.java
@@ -341,7 +341,7 @@ public class TemplateGenerator extends BaseService {
 		return data;
 	}
 
-	private Object getFieldLabel(UiFieldDTO field) {
+	private String getFieldLabel(UiFieldDTO field) {
 		List<String> labels = new ArrayList<>();
 		List<String> selectedLanguages = getRegistrationDTOFromSession().getSelectedLanguagesByApplicant();
 		for (String selectedLanguage : selectedLanguages) {
@@ -358,9 +358,14 @@ public class TemplateGenerator extends BaseService {
 		String value = getValue(registration.getDemographics().get(field.getId()));
 		if (value != null && !value.isEmpty()) {
 			data = new HashMap<>();
-			data.put("label", getFieldLabel(field));
-			data.put("value", getFieldValue(field));
-			//data.put("secondaryValue", getSecondaryLanguageValue(registration.getDemographics().get(field.getId())));
+			String fieldLabel = getFieldLabel(field);
+			String fieldValue = getFieldValue(field);
+			data.put("label", fieldLabel);
+			data.put("value", fieldValue);
+
+			//Added for backward compatibility(1.1.5.5 & 1.1.4.*), this support will be removed from next version
+			data.put("primaryLabel", fieldLabel);
+			data.put("primaryValue", fieldValue);
 		}
 		return data;
 	}


### PR DESCRIPTION
Template data map, compatibility added for 1.1.4 & 1.1.5.5 templates
From 1.2.0, labels and values of the demographics data map will be given with "label" and "value" keys.
For 1.1.4* and 1.1.5.5 templates, we have added backward support by retaining the "primaryLabel" and "primaryValue" keys.