### PR TITLE
Add fallthrough logic fix

### DIFF
--- a/registration/registration-services/src/main/java/io/mosip/registration/service/bio/impl/BioServiceImpl.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/service/bio/impl/BioServiceImpl.java
@@ -264,6 +264,7 @@ public class BioServiceImpl extends BaseService implements BioService {
 			case IRIS_DOUBLE:
 				thresholdScore = getGlobalConfigValueOf(RegistrationConstants.IRIS_THRESHOLD);
 				break;
+			case EXCEPTION_PHOTO:
 			case FACE:
 				thresholdScore = getGlobalConfigValueOf(RegistrationConstants.FACE_THRESHOLD);
 				break;


### PR DESCRIPTION
#783 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exception photos in biometric registration now correctly use the same quality threshold as standard face photos, ensuring consistent validation standards across all photo types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/registration-client/pull/787)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->