### PR TITLE
fix: NPE in getSDKScore() when SDK omits modality from quality map

### DIFF
--- a/registration/registration-services/src/main/java/io/mosip/registration/service/bio/impl/BioServiceImpl.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/service/bio/impl/BioServiceImpl.java
@@ -170,8 +170,13 @@ public class BioServiceImpl extends BaseService implements BioService {
 		Map<BiometricType, Float> scoreMap = bioAPIFactory
 				.getBioProvider(biometricType, BiometricFunction.QUALITY_CHECK)
 				.getModalityQuality(birList, null);
-		
-		return scoreMap.get(biometricType);
+
+		Float score = scoreMap.get(biometricType);
+		if (score == null) {
+			throw new BiometricException("SDK_SCORE_NULL",
+					"SDK did not return quality score for " + biometricType);
+		}
+		return score.doubleValue();
 	}
 
 	@Override

--- a/registration/registration-services/src/test/java/io/mosip/registration/bio/service/test/BioServiceTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/bio/service/test/BioServiceTest.java
@@ -319,6 +319,40 @@ public class BioServiceTest {
         Assert.assertEquals(45, score, 0);
     }
 
+    @Test(expected = BiometricException.class)
+    public void getSDKScoreMissingModalityKeyThrowsTest() throws BiometricException {
+        // SDK returns a map that does not contain the queried modality key
+        Map<BiometricType, Float> qualityMap = new HashMap<>();
+        qualityMap.put(BiometricType.FINGER, Float.valueOf("60.0")); // FACE key absent
+        BioProviderImpl_V_0_9 providerImpl_v_0_9 = Mockito.mock(BioProviderImpl_V_0_9.class);
+
+        Mockito.when(bioAPIFactory.getBioProvider(Mockito.any(), Mockito.any())).thenReturn(providerImpl_v_0_9);
+        Mockito.when(providerImpl_v_0_9.getModalityQuality(Mockito.any(), Mockito.any())).thenReturn(qualityMap);
+
+        BiometricsDto biometricsDto = new BiometricsDto();
+        biometricsDto.setBioAttribute("face");
+        biometricsDto.setQualityScore(70.0);
+        biometricsDto.setAttributeISO(new byte[0]);
+        biometricsDto.setModalityName(Modality.FACE.name());
+        bioService.getSDKScore(biometricsDto); // must throw BiometricException, not NPE
+    }
+
+    @Test(expected = BiometricException.class)
+    public void getSDKScoreEmptyMapThrowsTest() throws BiometricException {
+        // SDK returns an empty map — no entries at all
+        BioProviderImpl_V_0_9 providerImpl_v_0_9 = Mockito.mock(BioProviderImpl_V_0_9.class);
+
+        Mockito.when(bioAPIFactory.getBioProvider(Mockito.any(), Mockito.any())).thenReturn(providerImpl_v_0_9);
+        Mockito.when(providerImpl_v_0_9.getModalityQuality(Mockito.any(), Mockito.any())).thenReturn(Collections.emptyMap());
+
+        BiometricsDto biometricsDto = new BiometricsDto();
+        biometricsDto.setBioAttribute("face");
+        biometricsDto.setQualityScore(70.0);
+        biometricsDto.setAttributeISO(new byte[0]);
+        biometricsDto.setModalityName(Modality.FACE.name());
+        bioService.getSDKScore(biometricsDto); // must throw BiometricException, not NPE
+    }
+
     @Test
     public void buildBirTest() {
         BiometricsDto biometricsDto = new BiometricsDto();


### PR DESCRIPTION

## Summary

Fixes a `NullPointerException` in `BioServiceImpl.getSDKScore()` when
the SDK does not return a quality score entry for the requested
`BiometricType`.

## Root Cause

`scoreMap.get(biometricType)` was directly auto-unboxed to `double`.

If the SDK returned a map without the requested modality key,
`get()` returned `null`, causing a `NullPointerException`
during unboxing.

The exception bypassed the biometric error handling flow and was
eventually surfaced as `MDS_RCAPTURE_ERROR`.

## Fix #789 

Added a null check before unboxing the score value.

If the modality score is absent, the method now throws a
`BiometricException` with error code `SDK_SCORE_NULL`
instead of allowing an unchecked `NullPointerException`.

```java
Float score = scoreMap.get(biometricType);

if (score == null) {
    throw new BiometricException(
        "SDK_SCORE_NULL",
        "SDK did not return quality score for " + biometricType
    );
}

return score.doubleValue();
```

## Tests Added

Added regression test cases for:

- missing modality key in SDK response map
- empty SDK response map

Both tests verify that `BiometricException`
is thrown instead of `NullPointerException`.

## Files Changed

- `BioServiceImpl.java`
- `BioServiceTest.java`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced biometric quality score validation with explicit error handling for missing or invalid quality data.

* **Tests**
  * Added test coverage for biometric quality score exception scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/registration-client/pull/790)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->