### PR TITLE
fix: close leaked HTTP client in getHttpClientResponse()

### DIFF
--- a/registration/registration-services/src/main/java/io/mosip/registration/mdm/service/impl/MosipDeviceSpecificationHelper.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/mdm/service/impl/MosipDeviceSpecificationHelper.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
@@ -275,7 +276,7 @@ public class MosipDeviceSpecificationHelper {
 		}
 	}
 	
-	public CloseableHttpResponse getHttpClientResponse(String url, String method, String body) throws IOException {
+	public InputStream getHttpClientResponse(String url, String method, String body) throws IOException {
 		int timeout = getMDMConnectionTimeout(method);
 		LOGGER.debug("MDM HTTP CALL method : {}  with timeout {}", method, timeout);
 		RequestConfig requestConfig = RequestConfig.custom()
@@ -284,12 +285,36 @@ public class MosipDeviceSpecificationHelper {
 				.setConnectionRequestTimeout(timeout)
 				.build();
 		CloseableHttpClient client = HttpClients.createDefault();
-		StringEntity requestEntity = new StringEntity(body, ContentType.create("Content-Type", Consts.UTF_8));
-		HttpUriRequest httpUriRequest = RequestBuilder.create(method)
-				.setConfig(requestConfig)
-				.setUri(url)
-				.setEntity(requestEntity)
-				.build();
-		return client.execute(httpUriRequest);
+		try {
+			StringEntity requestEntity = new StringEntity(body, ContentType.create("Content-Type", Consts.UTF_8));
+			HttpUriRequest httpUriRequest = RequestBuilder.create(method)
+					.setConfig(requestConfig)
+					.setUri(url)
+					.setEntity(requestEntity)
+					.build();
+			CloseableHttpResponse response = client.execute(httpUriRequest);
+			if (response == null || response.getEntity() == null) {
+				response.close();
+				client.close();
+				return null;
+			}
+			return new FilterInputStream(response.getEntity().getContent()) {
+				@Override
+				public void close() throws IOException {
+					try {
+						super.close();
+					} finally {
+						try {
+							response.close();
+						} finally {
+							client.close();
+						}
+					}
+				}
+			};
+		} catch (IOException e) {
+			client.close();
+			throw e;
+		}
 	}
 }

--- a/registration/registration-services/src/main/java/io/mosip/registration/mdm/spec_0_9_5/service/impl/MosipDeviceSpecification_095_ProviderImpl.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/mdm/spec_0_9_5/service/impl/MosipDeviceSpecification_095_ProviderImpl.java
@@ -14,7 +14,6 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -138,13 +137,8 @@ public class MosipDeviceSpecification_095_ProviderImpl implements MosipDeviceSpe
 					timeout);
 
 			String request = objectMapper.writeValueAsString(streamRequestDTO);
-			CloseableHttpResponse response = mosipDeviceSpecificationHelper.getHttpClientResponse(
+			InputStream urlStream = mosipDeviceSpecificationHelper.getHttpClientResponse(
 					bioDevice.getCallbackId() + MosipBioDeviceConstants.STREAM_ENDPOINT, "STREAM", request);
-
-			InputStream urlStream = null;
-			if (response != null && response.getEntity() != null) {
-				urlStream = response.getEntity().getContent();
-			}
 
 			try {
 				byte[] byteArray = mosipDeviceSpecificationHelper.getJPEGByteArray(urlStream,

--- a/registration/registration-services/src/test/java/io/mosip/registration/bio/service/test/BioServiceTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/bio/service/test/BioServiceTest.java
@@ -133,6 +133,28 @@ public class BioServiceTest {
     }
 
     @Test
+    public void getHttpClientResponseReturnsStreamAndClosesTest() throws IOException {
+        MockResponse mockResponse = new MockResponse().setBody("stream-data");
+        mockWebServer.enqueue(mockResponse);
+
+        String url = mosipDeviceSpecificationHelper.buildUrl(4501, "stream");
+        InputStream stream = mosipDeviceSpecificationHelper.getHttpClientResponse(url, "GET", "");
+        Assert.assertNotNull(stream);
+        stream.close(); // must not throw; closes response and client
+    }
+
+    @Test
+    public void getHttpClientResponseNullOnNoEntityTest() throws IOException {
+        // Server returns 204 No Content — entity will be null
+        MockResponse mockResponse = new MockResponse().setResponseCode(204);
+        mockWebServer.enqueue(mockResponse);
+
+        String url = mosipDeviceSpecificationHelper.buildUrl(4501, "stream");
+        InputStream stream = mosipDeviceSpecificationHelper.getHttpClientResponse(url, "GET", "");
+        Assert.assertNull(stream);
+    }
+
+    @Test
     public void checkServiceAvailabilityTest() throws IOException {
         mockWebServer.enqueue(new MockResponse());
         String serviceUrl = mosipDeviceSpecificationHelper.buildUrl(4501, MosipBioDeviceConstants.DEVICE_INFO_ENDPOINT);


### PR DESCRIPTION

## Summary

Fixes an HTTP resource leak in `MosipDeviceSpecificationHelper#getHttpClientResponse()`
where a new `CloseableHttpClient` was created for every MDM request but never closed.

This affected stream, rcapture, and device info operations for spec `0.9.5`
devices and could progressively exhaust JVM socket/file descriptors during
normal registration sessions.

Fixes #791

---

## Root Cause

`getHttpClientResponse()` returned a raw `CloseableHttpResponse` while the
internally created `CloseableHttpClient` remained unmanaged.

```java
CloseableHttpClient client = HttpClients.createDefault();
return client.execute(httpUriRequest);
```

Because the client lifecycle was detached from the caller, sockets and HTTP
connections accumulated over repeated biometric operations.

---

## Fix

Changed the method return type from `CloseableHttpResponse` to `InputStream`.

The method now:

* wraps response content in a `FilterInputStream`
* closes both `CloseableHttpResponse` and `CloseableHttpClient`
  when the stream is closed
* safely closes the client on `IOException` before rethrowing

Updated the only caller in
`MosipDeviceSpecification_095_ProviderImpl` to consume `InputStream`
directly and removed the unused `CloseableHttpResponse` import.

---

## Files Changed

* `MosipDeviceSpecificationHelper.java`

  * fixed HTTP client/resource leak
  * changed return type to `InputStream`

* `MosipDeviceSpecification_095_ProviderImpl.java`

  * updated caller implementation

* `BioServiceTest.java`

  * added stream lifecycle test
  * added `204 No Content` handling test

