### PR TITLE
refactor: ensure thread safety in ApplicationContext with ConcurrentHashMap and synchronized initialization

### DIFF
--- a/registration/registration-services/src/main/java/io/mosip/registration/context/ApplicationContext.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/context/ApplicationContext.java
@@ -6,6 +6,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ResourceBundle;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -36,7 +37,7 @@ public class ApplicationContext {
 	private static ApplicationContext applicationContext;
 
 	/** The application map. */
-	private static Map<String, Object> applicationMap = new HashMap<>();
+	private static Map<String, Object> applicationMap = new ConcurrentHashMap<>();
 
 	/** The application languge. */
 	private String applicationLanguge;
@@ -60,7 +61,7 @@ public class ApplicationContext {
 		this.optionalLanguages = optionalLanguages;
 	}
 
-	private static Map<String, ResourceBundle> resourceBundleMap = new HashMap<>();
+	private static Map<String, ResourceBundle> resourceBundleMap = new ConcurrentHashMap<>();
 
 	/**
 	 * Checks if is primary language right to left.
@@ -174,7 +175,7 @@ public class ApplicationContext {
 	 *
 	 * @return single instance of ApplicationContext
 	 */
-	public static ApplicationContext getInstance() {
+	public static synchronized ApplicationContext getInstance() {
 		if (applicationContext == null) {
 			applicationContext = new ApplicationContext();
 			applicationContext.authTokenDTO = new AuthTokenDTO();


### PR DESCRIPTION
## Description
This PR addresses critical thread-safety issues in `ApplicationContext.java` that could lead to intermittent `ConcurrentModificationException`, inconsistent global state, and potential data corruption during concurrent background synchronization tasks.

---

## Key Changes
### Replaced `HashMap` with `ConcurrentHashMap`
Updated both:
- `applicationMap`
- `resourceBundleMap`
to use `ConcurrentHashMap` for safe concurrent access across the JavaFX UI thread and multiple background jobs.

### Synchronized Singleton Initialization
Added the `synchronized` keyword to the `getInstance()` method to prevent race conditions and possible double initialization during the first creation of `ApplicationContext`.

### Thread-Safe Imports
Added the required:
```java
import java.util.concurrent.ConcurrentHashMap; 
```
---

## Why is this needed?

`ApplicationContext` acts as a shared global resource accessed by the JavaFX UI thread, Job Scheduler, Packet Sync services, Master Sync jobs, and other background workers. 
The previous implementation relied on unsynchronized `HashMap` structures, which are not thread-safe. Concurrent read/write operations during synchronization tasks could result in:

- `ConcurrentModificationException`
- Inconsistent application configuration state
- UI freezes or intermittent crashes
- Potential startup race conditions during singleton initialization

## Impact
- Resolves intermittent `ConcurrentModificationException` during heavy sync operations
- Improves overall application stability under concurrent workloads
- Prevents potential race conditions during application startup
- Ensures safer concurrent access to global configuration and resource bundle data

fixes #793 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application stability and thread-safety for concurrent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/registration-client/pull/794)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->