### PR TITLE
T1 (#808): softwareUpdateHandler — resumable downloads to .artifacts/

### DIFF
--- a/registration/registration-services/src/main/java/io/mosip/registration/update/ResumableDownloader.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/ResumableDownloader.java
@@ -57,7 +57,10 @@ public final class ResumableDownloader {
      * @param fileName       the final file name within {@code targetDir}
      * @param connectTimeout connection timeout in milliseconds
      * @param readTimeout    read timeout in milliseconds (0 = infinite)
-     * @throws IOException if the download cannot be completed
+     * @throws IOException              if the download cannot be completed
+     * @throws IllegalArgumentException if {@code fileName} is blank or contains a path separator or a
+     *                                  {@code ..} sequence (guards against path-traversal writes outside
+     *                                  {@code targetDir})
      */
     public static void download(String url, String targetDir, String fileName,
                                 int connectTimeout, int readTimeout) throws IOException {
@@ -343,6 +346,12 @@ public final class ResumableDownloader {
         private final File meta;
 
         private Artifact(File dir, String name) {
+            if (name == null || name.isEmpty()
+                    || name.indexOf('/') >= 0 || name.indexOf('\\') >= 0
+                    || name.contains("..")) {
+                throw new IllegalArgumentException(
+                        "Illegal download file name (path traversal attempt?): " + name);
+            }
             this.dir = dir;
             this.name = name;
             this.target = new File(dir, name);

--- a/registration/registration-services/src/main/java/io/mosip/registration/update/ResumableDownloader.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/ResumableDownloader.java
@@ -1,0 +1,372 @@
+package io.mosip.registration.update;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.RandomAccessFile;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * Resumable HTTP file download used by {@code softwareUpdateHandler} to stage upgrade artifacts into
+ * {@code .artifacts/}.
+ * <p>
+ * The implementation depends only on the JDK + slf4j (no registration-client / registration-services
+ * types) so that in T2 it can be moved unchanged into the Java 11 {@code registration-launcher-common}
+ * module and shared with {@code _launcher.jar}. Timeouts are passed in as parameters rather than read
+ * from the services {@code ApplicationContext} for the same reason.
+ * <p>
+ * <b>Resume safety.</b> A partial download is only resumed when the server's validator (a strong
+ * {@code ETag}, falling back to {@code Last-Modified}) captured when the partial was first written
+ * still matches — enforced via an {@code If-Range} request and a {@code <file>.part.meta} sidecar.
+ * If the resource changed (or the server omits a validator) the partial is discarded and the file is
+ * re-downloaded from scratch, so bytes from two different resource versions can never be spliced
+ * together. The completed transfer is verified against {@code Content-Length} before the staged
+ * {@code .part} is atomically moved onto the final file.
+ */
+public final class ResumableDownloader {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResumableDownloader.class);
+    private static final String PART_SUFFIX = ".part";
+    private static final String META_SUFFIX = ".part.meta";
+    private static final int HTTP_RANGE_NOT_SATISFIABLE = 416;
+    private static final int BUFFER_SIZE = 8192;
+
+    private ResumableDownloader() {
+        // utility class
+    }
+
+    /**
+     * Downloads {@code url} into {@code targetDir/fileName} with resume support.
+     * <p>
+     * The content is staged into a {@code <fileName>.part} file. If a partial file (and its validator
+     * sidecar) already exists from an interrupted attempt, the download resumes from the last received
+     * byte using an {@code If-Range}-guarded HTTP {@code Range} request; if the server indicates the
+     * resource has changed it transparently restarts from scratch. On successful completion the part
+     * file is atomically moved onto the final file. If the download fails the part file is retained so
+     * a subsequent call can resume.
+     *
+     * @param url            the source URL
+     * @param targetDir      the directory the file should be written into (created if missing)
+     * @param fileName       the final file name within {@code targetDir}
+     * @param connectTimeout connection timeout in milliseconds
+     * @param readTimeout    read timeout in milliseconds (0 = infinite)
+     * @throws IOException if the download cannot be completed
+     */
+    public static void download(String url, String targetDir, String fileName,
+                                int connectTimeout, int readTimeout) throws IOException {
+        LOGGER.info("Resumable download invoked, url : {}, target : {}/{}", url, targetDir, fileName);
+        File dir = new File(targetDir);
+        if (!dir.exists() && !dir.mkdirs() && !dir.exists()) {
+            throw new IOException("Unable to create target directory " + dir.getAbsolutePath());
+        }
+        Artifact artifact = new Artifact(dir, fileName);
+
+        // At most two attempts: a resume attempt, and (only when the server signals the partial is
+        // stale / unusable) one fresh restart with the stale part discarded.
+        boolean allowResume = true;
+        for (int attempt = 0; attempt < 2; attempt++) {
+            if (attemptDownload(url, artifact, allowResume, connectTimeout, readTimeout)) {
+                return;
+            }
+            allowResume = false; // the partial was discarded; the next attempt starts from scratch
+        }
+        throw new IOException("Failed to download " + url + " after restart");
+    }
+
+    /**
+     * Performs a single download attempt.
+     *
+     * @return {@code true} if the file was completed and finalized; {@code false} if the partial was
+     *         found stale/unusable and discarded, so the caller should restart from scratch.
+     */
+    private static boolean attemptDownload(String url, Artifact artifact, boolean allowResume,
+                                           int connectTimeout, int readTimeout) throws IOException {
+        String validator = allowResume ? resumeValidator(artifact) : null;
+        long existing = (validator != null) ? artifact.part.length() : 0L;
+
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        connection.setConnectTimeout(connectTimeout);
+        connection.setReadTimeout(readTimeout);
+        if (existing > 0) {
+            connection.setRequestProperty("Range", "bytes=" + existing + "-");
+            connection.setRequestProperty("If-Range", validator);
+            LOGGER.info("Resuming {} from byte {} (If-Range guarded)", artifact.name, existing);
+        }
+        try {
+            connection.connect();
+            int status = connection.getResponseCode();
+            boolean append;
+            if (status == HttpURLConnection.HTTP_PARTIAL) {            // 206 - server honoured Range
+                long start = parseContentRangeStart(connection.getHeaderField("Content-Range"));
+                if (start != existing) {
+                    LOGGER.warn("206 for {} started at byte {} but expected {}; discarding and restarting",
+                            artifact.name, start, existing);
+                    artifact.discard();
+                    return false;
+                }
+                append = true;
+            } else if (status == HttpURLConnection.HTTP_OK) {          // 200 - fresh body (or If-Range mismatch)
+                append = false;
+                existing = 0L;
+                // Persist the validator so a later interrupted attempt can resume this exact resource.
+                writeValidator(artifact.meta, extractValidator(connection));
+            } else if (status == HTTP_RANGE_NOT_SATISFIABLE) {         // 416 - part is at/over server size
+                return handleRangeNotSatisfiable(connection, artifact);
+            } else {
+                throw new IOException("Unexpected HTTP status " + status + " while downloading " + url);
+            }
+
+            long contentLength = connection.getContentLengthLong();
+            ensureSpaceForWrite(artifact.dir, artifact.part, contentLength, append);
+            writeBody(connection, artifact.part, append, existing);
+            verifyComplete(artifact, contentLength, append, existing);
+            artifact.finalizeOnto();
+            LOGGER.info("Resumable download completed : {}", artifact.name);
+            return true;
+        } catch (IOException e) {
+            LOGGER.error("Failed to download {} (partial file retained for resume)", url, e);
+            throw e;
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    /** Handles a 416 response: finalize if the part is already the complete file, else discard + restart. */
+    private static boolean handleRangeNotSatisfiable(HttpURLConnection connection, Artifact artifact)
+            throws IOException {
+        long total = parseContentRangeTotal(connection.getHeaderField("Content-Range"));
+        long partLength = artifact.part.exists() ? artifact.part.length() : 0L;
+        if (total >= 0 && partLength == total) {
+            LOGGER.info("Range not satisfiable for {} and part matches server size; finalizing", artifact.name);
+            artifact.finalizeOnto();
+            return true;
+        }
+        LOGGER.warn("416 for {} but local part ({} bytes) != server total ({}); restarting fresh",
+                artifact.name, partLength, total);
+        artifact.discard();
+        return false;
+    }
+
+    /**
+     * Returns the validator stored for a resumable partial, or {@code null} if the partial cannot be
+     * safely resumed (no partial, or no stored validator) — in which case any stale partial is removed.
+     */
+    private static String resumeValidator(Artifact artifact) throws IOException {
+        if (!artifact.part.exists()) {
+            return null;
+        }
+        String validator = readValidator(artifact.meta);
+        if (validator == null) {
+            LOGGER.warn("Partial {} has no stored validator; cannot safely resume, restarting", artifact.name);
+            Files.deleteIfExists(artifact.part.toPath());
+        }
+        return validator;
+    }
+
+    /** Streams the response body into the part file, appending from {@code existing} or overwriting. */
+    private static void writeBody(HttpURLConnection connection, File partFile, boolean append, long existing)
+            throws IOException {
+        try (InputStream in = connection.getInputStream();
+             RandomAccessFile out = new RandomAccessFile(partFile, "rw")) {
+            if (append) {
+                out.seek(existing);
+            } else {
+                out.setLength(0);
+            }
+            byte[] buffer = new byte[BUFFER_SIZE];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                out.write(buffer, 0, read);
+            }
+        }
+    }
+
+    /**
+     * Detects a truncated transfer: when the length is known, what landed on disk must match it. A
+     * premature EOF (server/connection closed early) can otherwise end the read loop cleanly and
+     * finalize a short, corrupt file. The part is retained (this throws) so it can resume.
+     */
+    private static void verifyComplete(Artifact artifact, long contentLength, boolean append, long existing)
+            throws IOException {
+        if (contentLength < 0) {
+            return;
+        }
+        long expected = (append ? existing : 0L) + contentLength;
+        if (artifact.part.length() != expected) {
+            throw new IOException("Incomplete download of " + artifact.name + ": expected " + expected
+                    + " bytes but got " + artifact.part.length() + " (partial retained for resume)");
+        }
+    }
+
+    /**
+     * Disk-space guard for the write about to happen. On a full (200) restart the existing part will be
+     * truncated, so its bytes are added back to the available figure. When the content length is
+     * unknown (e.g. chunked transfer with no {@code Content-Length}) the pre-check cannot be performed
+     * and is skipped with a warning (rather than silently passing a zero requirement).
+     */
+    private static void ensureSpaceForWrite(File dir, File partFile, long contentLength, boolean append)
+            throws IOException {
+        if (contentLength < 0) {
+            LOGGER.warn("Content-Length unknown for {}; skipping disk-space pre-check", dir.getAbsolutePath());
+            return;
+        }
+        long freeable = append ? 0L : (partFile.exists() ? partFile.length() : 0L);
+        long usableSpace = dir.getUsableSpace() + freeable;
+        if (contentLength > usableSpace) {
+            LOGGER.error("Insufficient disk space at {} : required {} bytes, available {} bytes",
+                    dir.getAbsolutePath(), contentLength, usableSpace);
+            throw new IOException("Not enough space available to download. Required: " + contentLength
+                    + " bytes, Available: " + usableSpace + " bytes");
+        }
+    }
+
+    /**
+     * Picks a validator usable with {@code If-Range}: a strong {@code ETag} if present, else
+     * {@code Last-Modified}. Weak ETags ({@code W/...}) are not valid for byte-range validation per
+     * RFC 7233 and are ignored. Returns {@code null} when the server provides neither — in which case
+     * the download cannot be safely resumed and is restarted instead.
+     */
+    private static String extractValidator(HttpURLConnection connection) {
+        String etag = connection.getHeaderField("ETag");
+        if (etag != null) {
+            etag = etag.trim();
+            if (!etag.isEmpty() && !etag.startsWith("W/")) {
+                return etag;
+            }
+        }
+        String lastModified = connection.getHeaderField("Last-Modified");
+        if (lastModified != null && !lastModified.trim().isEmpty()) {
+            return lastModified.trim();
+        }
+        return null;
+    }
+
+    private static String readValidator(File metaFile) {
+        if (!metaFile.exists()) {
+            return null;
+        }
+        try {
+            String value = new String(Files.readAllBytes(metaFile.toPath()), StandardCharsets.UTF_8).trim();
+            return value.isEmpty() ? null : value;
+        } catch (IOException e) {
+            LOGGER.warn("Could not read validator {} : {}", metaFile, e.getMessage());
+            return null;
+        }
+    }
+
+    private static void writeValidator(File metaFile, String validator) {
+        try {
+            if (validator == null) {
+                Files.deleteIfExists(metaFile.toPath());
+            } else {
+                Files.write(metaFile.toPath(), validator.getBytes(StandardCharsets.UTF_8));
+            }
+        } catch (IOException e) {
+            LOGGER.warn("Could not persist validator {} : {}", metaFile, e.getMessage());
+        }
+    }
+
+    /** Parses the start offset from a {@code Content-Range: bytes <start>-<end>/<total>} header; -1 if unknown. */
+    private static long parseContentRangeStart(String contentRange) {
+        if (contentRange == null) {
+            return -1;
+        }
+        String value = contentRange.trim();
+        int space = value.indexOf(' ');
+        if (space >= 0) {
+            value = value.substring(space + 1);
+        }
+        int dash = value.indexOf('-');
+        if (dash <= 0) {
+            return -1;
+        }
+        try {
+            return Long.parseLong(value.substring(0, dash).trim());
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    /** Parses the total size from a {@code Content-Range: bytes <range>/<total>} header; -1 if unknown. */
+    private static long parseContentRangeTotal(String contentRange) {
+        if (contentRange == null) {
+            return -1;
+        }
+        int slash = contentRange.lastIndexOf('/');
+        if (slash < 0 || slash == contentRange.length() - 1) {
+            return -1;
+        }
+        String total = contentRange.substring(slash + 1).trim();
+        if ("*".equals(total)) {
+            return -1;
+        }
+        try {
+            return Long.parseLong(total);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    /**
+     * Guards against starting a write that cannot fit on the target's partition. Checks the usable
+     * space of the actual target directory's partition rather than the file-system root, which is
+     * important on Windows where the install drive may differ from {@code C:\}.
+     *
+     * @param targetDir     the directory the data will be written to
+     * @param requiredBytes the number of bytes about to be written
+     * @throws IOException if there is insufficient usable space
+     */
+    public static void ensureSpace(File targetDir, long requiredBytes) throws IOException {
+        File dir = (targetDir != null && targetDir.exists()) ? targetDir : new File(".");
+        long usableSpace = dir.getUsableSpace();
+        if (requiredBytes > usableSpace) {
+            LOGGER.error("Insufficient disk space at {} : required {} bytes, available {} bytes",
+                    dir.getAbsolutePath(), requiredBytes, usableSpace);
+            throw new IOException("Not enough space available to download. Required: " + requiredBytes
+                    + " bytes, Available: " + usableSpace + " bytes");
+        }
+    }
+
+    /** The set of files involved in staging one download: the final file, its {@code .part}, and its validator sidecar. */
+    private static final class Artifact {
+        private final File dir;
+        private final String name;
+        private final File target;
+        private final File part;
+        private final File meta;
+
+        private Artifact(File dir, String name) {
+            this.dir = dir;
+            this.name = name;
+            this.target = new File(dir, name);
+            this.part = new File(dir, name + PART_SUFFIX);
+            this.meta = new File(dir, name + META_SUFFIX);
+        }
+
+        /** Discards a stale partial download and its validator sidecar. */
+        private void discard() throws IOException {
+            Files.deleteIfExists(part.toPath());
+            Files.deleteIfExists(meta.toPath());
+        }
+
+        /**
+         * Atomically moves the completed part file onto the target file and removes the validator
+         * sidecar. Falls back to a non-atomic replace when the file system has no atomic move.
+         */
+        private void finalizeOnto() throws IOException {
+            try {
+                Files.move(part.toPath(), target.toPath(), StandardCopyOption.ATOMIC_MOVE);
+            } catch (IOException atomicMoveUnsupported) {
+                Files.move(part.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+            Files.deleteIfExists(meta.toPath());
+        }
+    }
+}

--- a/registration/registration-services/src/main/java/io/mosip/registration/update/ResumableDownloader.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/ResumableDownloader.java
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 package io.mosip.registration.update;
 
 import org.slf4j.Logger;

--- a/registration/registration-services/src/main/java/io/mosip/registration/update/ResumableDownloader.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/ResumableDownloader.java
@@ -133,6 +133,13 @@ public final class ResumableDownloader {
             } else if (status == HttpURLConnection.HTTP_OK) {          // 200 - fresh body (or If-Range mismatch)
                 append = false;
                 existing = 0L;
+                // Discard any stale partial BEFORE persisting the new validator. Writing the new
+                // validator while old bytes still sit in .part would, if the process died before
+                // writeBody truncates them (e.g. ensureSpaceForWrite throws), leave a new validator
+                // paired with stale bytes — which the next resume would splice onto the new resource
+                // via If-Range. Deleting first keeps .part and .meta in sync (and frees the old bytes
+                // so the disk-space pre-check below sees them as available).
+                Files.deleteIfExists(artifact.part.toPath());
                 // Persist the validator so a later interrupted attempt can resume this exact resource.
                 writeValidator(artifact.meta, extractValidator(connection));
             } else if (status == HTTP_RANGE_NOT_SATISFIABLE) {         // 416 - part is at/over server size

--- a/registration/registration-services/src/main/java/io/mosip/registration/update/ResumableDownloader.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/ResumableDownloader.java
@@ -34,6 +34,12 @@ import java.nio.file.StandardCopyOption;
  * re-downloaded from scratch, so bytes from two different resource versions can never be spliced
  * together. The completed transfer is verified against {@code Content-Length} before the staged
  * {@code .part} is atomically moved onto the final file.
+ * <p>
+ * <b>Integrity scope.</b> This class verifies transfer <i>completeness</i> (byte count) only, not
+ * content <i>integrity</i>. Cryptographic verification of a downloaded artifact (SHA / HMAC against the
+ * signed {@code MANIFEST.MF}) is deliberately performed downstream by the caller
+ * ({@code softwareUpdateHandler} and the launcher's manifest verifier) before the artifact is placed
+ * into use, so it is intentionally out of scope here.
  */
 public final class ResumableDownloader {
 
@@ -102,6 +108,10 @@ public final class ResumableDownloader {
         HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
         connection.setConnectTimeout(connectTimeout);
         connection.setReadTimeout(readTimeout);
+        // Force an uncompressed transfer: with a byte Range request, transparent gzip anywhere in the
+        // path would make the Content-Length (compressed) and the byte offsets disagree with the bytes
+        // written to .part, breaking both the completeness check and any subsequent resume.
+        connection.setRequestProperty("Accept-Encoding", "identity");
         if (existing > 0) {
             connection.setRequestProperty("Range", "bytes=" + existing + "-");
             connection.setRequestProperty("If-Range", validator);

--- a/registration/registration-services/src/main/java/io/mosip/registration/update/SoftwareUpdateHandler.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/SoftwareUpdateHandler.java
@@ -319,8 +319,10 @@ public class SoftwareUpdateHandler extends BaseService {
 		serverManifest.write(new FileOutputStream(manifestFile));
 		setLocalManifest();
 
-		SoftwareUpdateUtil.clearTempDirectory();
-
+		// From 1.3.0 the handler is download-and-record only: artifacts are staged into .artifacts/
+		// (resumable, never into lib/) and the .artifacts/ directory is intentionally NOT cleared so an
+		// interrupted download can resume from its .part file on the next run. Unzipping and applying to
+		// lib/ is the launcher's / run.bat's job (T2), not the handler's.
 		Map<String, Attributes> localAttributes = localManifest.getEntries();
 		for (Map.Entry<String, Attributes> entry : localAttributes.entrySet()) {
 			File file = new File(libFolder + SLASH + entry.getKey());
@@ -328,14 +330,14 @@ public class SoftwareUpdateHandler extends BaseService {
 
 			if(!file.exists()) {
 				LOGGER.info("{} file doesn't exists, downloading it", entry.getKey());
-				SoftwareUpdateUtil.download(url, entry.getKey());
+				SoftwareUpdateUtil.downloadResumable(url, SoftwareUpdateUtil.ARTIFACTS_DIRECTORY, entry.getKey());
 				LOGGER.info("Successfully downloaded the file : {}", entry.getKey());
 				continue;
 			}
 
 			if(!SoftwareUpdateUtil.validateJarChecksum(file, entry.getValue())) {
 				LOGGER.info("{} file checksum validation failed, downloading it", entry.getKey());
-				SoftwareUpdateUtil.download(url, entry.getKey());
+				SoftwareUpdateUtil.downloadResumable(url, SoftwareUpdateUtil.ARTIFACTS_DIRECTORY, entry.getKey());
 				LOGGER.info("Successfully downloaded the latest file : {}", entry.getKey());
 			}
 		}

--- a/registration/registration-services/src/main/java/io/mosip/registration/update/SoftwareUpdateUtil.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/SoftwareUpdateUtil.java
@@ -31,8 +31,10 @@ public class SoftwareUpdateUtil {
     private static final String MANIFEST_FILE_NAME = "MANIFEST.MF";
     private static final String MANIFEST_SIG_FILE_NAME = MANIFEST_FILE_NAME + ".sig";
     public static final String ARTIFACTS_DIRECTORY = ".artifacts";
+    // 50s timeout for establishing the connection to the upgrade server.
     private static final int DEFAULT_CONNECTION_TIMEOUT = 50000;
-    private static final int DEFAULT_READ_TIMEOUT = 0;
+    // 30s inactivity-between-bytes timeout (not a total cap); avoids hanging forever on a stalled connection.
+    private static final int DEFAULT_READ_TIMEOUT = 30000;
 
     protected static boolean deleteUnknownJars(Manifest localManifest) throws IOException {
         StringBuilder builder = new StringBuilder();

--- a/registration/registration-services/src/main/java/io/mosip/registration/update/SoftwareUpdateUtil.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/SoftwareUpdateUtil.java
@@ -141,23 +141,6 @@ public class SoftwareUpdateUtil {
         }
     }
 
-    /**
-     * Guards against starting a download that cannot fit on the target's partition. Delegates to
-     * {@link ResumableDownloader#ensureSpace(File, long)} and translates the low-level
-     * {@link IOException} into the service-layer {@link RegBaseCheckedException}.
-     *
-     * @param targetDir     the directory the download will be written to
-     * @param requiredBytes the number of bytes about to be written
-     * @throws RegBaseCheckedException if there is insufficient usable space
-     */
-    protected static void ensureSpace(File targetDir, long requiredBytes) throws RegBaseCheckedException {
-        try {
-            ResumableDownloader.ensureSpace(targetDir, requiredBytes);
-        } catch (IOException e) {
-            throw new RegBaseCheckedException("REG-BUILD-004", e.getMessage(), e);
-        }
-    }
-
     private static int getTimeout(String key, int defaultValue) {
         try {
             Integer value = ApplicationContext.getIntValueFromApplicationMap(key);

--- a/registration/registration-services/src/main/java/io/mosip/registration/update/SoftwareUpdateUtil.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/SoftwareUpdateUtil.java
@@ -30,6 +30,9 @@ public class SoftwareUpdateUtil {
     private static final String TEMP_DIRECTORY = ".TEMP";
     private static final String MANIFEST_FILE_NAME = "MANIFEST.MF";
     private static final String MANIFEST_SIG_FILE_NAME = MANIFEST_FILE_NAME + ".sig";
+    public static final String ARTIFACTS_DIRECTORY = ".artifacts";
+    private static final int DEFAULT_CONNECTION_TIMEOUT = 50000;
+    private static final int DEFAULT_READ_TIMEOUT = 0;
 
     protected static boolean deleteUnknownJars(Manifest localManifest) throws IOException {
         StringBuilder builder = new StringBuilder();
@@ -115,6 +118,57 @@ public class SoftwareUpdateUtil {
         throw new RegBaseCheckedException("REG-BUILD-005", "Failed to download " + url);
     }
 
+    /**
+     * Downloads {@code url} into {@code targetDir/fileName} with resume support.
+     * <p>
+     * Delegates to {@link ResumableDownloader}, supplying the configured timeouts and translating the
+     * low-level {@link IOException} into the service-layer {@link RegBaseCheckedException}. Used by
+     * {@code softwareUpdateHandler} to stage upgrade artifacts into {@link #ARTIFACTS_DIRECTORY}.
+     *
+     * @param url       the source URL
+     * @param targetDir the directory the file should be written into (created if missing)
+     * @param fileName  the final file name within {@code targetDir}
+     * @throws RegBaseCheckedException if the download cannot be completed
+     */
+    protected static void downloadResumable(String url, String targetDir, String fileName) throws RegBaseCheckedException {
+        try {
+            ResumableDownloader.download(url, targetDir, fileName,
+                    getTimeout(CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT),
+                    getTimeout(READ_TIMEOUT, DEFAULT_READ_TIMEOUT));
+        } catch (IOException e) {
+            LOGGER.error("Failed to download {}", url, e);
+            throw new RegBaseCheckedException("REG-BUILD-005", "Failed to download " + url);
+        }
+    }
+
+    /**
+     * Guards against starting a download that cannot fit on the target's partition. Delegates to
+     * {@link ResumableDownloader#ensureSpace(File, long)} and translates the low-level
+     * {@link IOException} into the service-layer {@link RegBaseCheckedException}.
+     *
+     * @param targetDir     the directory the download will be written to
+     * @param requiredBytes the number of bytes about to be written
+     * @throws RegBaseCheckedException if there is insufficient usable space
+     */
+    protected static void ensureSpace(File targetDir, long requiredBytes) throws RegBaseCheckedException {
+        try {
+            ResumableDownloader.ensureSpace(targetDir, requiredBytes);
+        } catch (IOException e) {
+            throw new RegBaseCheckedException("REG-BUILD-004", e.getMessage());
+        }
+    }
+
+    private static int getTimeout(String key, int defaultValue) {
+        try {
+            Integer value = ApplicationContext.getIntValueFromApplicationMap(key);
+            return value == null ? defaultValue : value;
+        } catch (RuntimeException e) {
+            // e.g. a non-numeric configured value -> NumberFormatException; fall back to the default
+            LOGGER.warn("Invalid value for {}, using default {} : {}", key, defaultValue, e.getMessage());
+            return defaultValue;
+        }
+    }
+
     protected static boolean deleteFile(String filePath) {
         LOGGER.info("Deleting file {}", filePath);
         Path path = Path.of(filePath);
@@ -150,11 +204,4 @@ public class SoftwareUpdateUtil {
             LOGGER.error("Failed to clean and delete temp", e);
         }
     }
-
-    /*private static boolean hasSpace(int bytes) throws RegBaseCheckedException {
-        boolean hasSpace = bytes < new File(File.separator).getFreeSpace();
-        if(!hasSpace)
-            throw new RegBaseCheckedException("REG-BUILD-004", "Not enough space available");
-        return true;
-    }*/
 }

--- a/registration/registration-services/src/main/java/io/mosip/registration/update/SoftwareUpdateUtil.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/SoftwareUpdateUtil.java
@@ -137,7 +137,7 @@ public class SoftwareUpdateUtil {
                     getTimeout(READ_TIMEOUT, DEFAULT_READ_TIMEOUT));
         } catch (IOException e) {
             LOGGER.error("Failed to download {}", url, e);
-            throw new RegBaseCheckedException("REG-BUILD-005", "Failed to download " + url);
+            throw new RegBaseCheckedException("REG-BUILD-005", "Failed to download " + url, e);
         }
     }
 
@@ -154,7 +154,7 @@ public class SoftwareUpdateUtil {
         try {
             ResumableDownloader.ensureSpace(targetDir, requiredBytes);
         } catch (IOException e) {
-            throw new RegBaseCheckedException("REG-BUILD-004", e.getMessage());
+            throw new RegBaseCheckedException("REG-BUILD-004", e.getMessage(), e);
         }
     }
 

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/update/ResumableDownloaderTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/update/ResumableDownloaderTest.java
@@ -42,7 +42,7 @@ public class ResumableDownloaderTest {
     // ---------------------------------------------------------------------
 
     @Test
-    public void fullDownload_success_cleansPartAndMeta() throws Exception {
+    public void download_fullResponse_succeedsAndCleansSidecars() throws Exception {
         byte[] payload = randomPayload(2000);
         HttpServer server = rangeServer(payload, ETAG, null, true);
         File dir = tempDir();
@@ -59,7 +59,7 @@ public class ResumableDownloaderTest {
     }
 
     @Test
-    public void resumesFromPartial_appends() throws Exception {
+    public void download_partialPresent_resumesByAppending() throws Exception {
         byte[] payload = randomPayload(2000);
         HttpServer server = rangeServer(payload, ETAG, null, true);
         File dir = tempDir();
@@ -81,7 +81,7 @@ public class ResumableDownloaderTest {
     // ---------------------------------------------------------------------
 
     @Test
-    public void resume206WithWrongStart_discardsAndRestarts() throws Exception {
+    public void download_206WrongStartOffset_discardsAndRestarts() throws Exception {
         byte[] payload = randomPayload(2000);
         // Serves 206 but always claims it started at byte 0, regardless of the requested offset.
         HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
@@ -123,7 +123,7 @@ public class ResumableDownloaderTest {
     // ---------------------------------------------------------------------
 
     @Test
-    public void rangeNotSatisfiable_partLargerThanTotal_restartsFresh() throws Exception {
+    public void download_416PartLargerThanTotal_restartsFresh() throws Exception {
         byte[] payload = randomPayload(2000);
         HttpServer server = rangeServer(payload, ETAG, null, true);
         File dir = tempDir();
@@ -146,7 +146,7 @@ public class ResumableDownloaderTest {
     // ---------------------------------------------------------------------
 
     @Test
-    public void weakEtagIgnored_lastModifiedUsedAsValidator() throws Exception {
+    public void download_weakEtag_usesLastModifiedValidator() throws Exception {
         byte[] payload = randomPayload(4000);
         // A weak ETag (W/...) is invalid for byte-range validation -> Last-Modified must be chosen.
         HttpServer server = truncatingServer(payload, "W/\"weak\"", LAST_MODIFIED);
@@ -161,7 +161,7 @@ public class ResumableDownloaderTest {
     }
 
     @Test
-    public void noEtag_lastModifiedUsedAsValidator() throws Exception {
+    public void download_noEtag_usesLastModifiedValidator() throws Exception {
         byte[] payload = randomPayload(4000);
         HttpServer server = truncatingServer(payload, null, LAST_MODIFIED);
         File dir = tempDir();
@@ -178,7 +178,7 @@ public class ResumableDownloaderTest {
     // ---------------------------------------------------------------------
 
     @Test
-    public void noValidatorHeaders_metaNotWritten() throws Exception {
+    public void download_noValidatorHeaders_writesNoMeta() throws Exception {
         byte[] payload = randomPayload(4000);
         HttpServer server = truncatingServer(payload, null, null);
         File dir = tempDir();
@@ -196,7 +196,7 @@ public class ResumableDownloaderTest {
     // ---------------------------------------------------------------------
 
     @Test
-    public void chunkedUnknownLength_completes() throws Exception {
+    public void download_chunkedUnknownLength_completes() throws Exception {
         byte[] payload = randomPayload(2000);
         HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
         server.createContext("/file", exchange -> {
@@ -258,7 +258,7 @@ public class ResumableDownloaderTest {
     // ---------------------------------------------------------------------
 
     @Test
-    public void targetDirectoryCreatedWhenMissing() throws Exception {
+    public void download_missingTargetDir_createsDirectory() throws Exception {
         byte[] payload = randomPayload(1000);
         HttpServer server = rangeServer(payload, ETAG, null, true);
         File base = tempDir();
@@ -280,7 +280,7 @@ public class ResumableDownloaderTest {
     // ---------------------------------------------------------------------
 
     @Test
-    public void finalizeOverwritesExistingTarget() throws Exception {
+    public void download_existingTarget_overwrites() throws Exception {
         byte[] payload = randomPayload(2000);
         HttpServer server = rangeServer(payload, ETAG, null, true);
         File dir = tempDir();
@@ -301,19 +301,19 @@ public class ResumableDownloaderTest {
     // ---------------------------------------------------------------------
 
     @Test(expected = IllegalArgumentException.class)
-    public void blankFileName_rejected() throws Exception {
+    public void download_blankFileName_throwsIllegalArgument() throws Exception {
         ResumableDownloader.download("http://localhost/file", tempDir().getAbsolutePath(), "",
                 CONNECT_TIMEOUT, READ_TIMEOUT);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void pathTraversalName_rejected() throws Exception {
+    public void download_pathTraversalName_throwsIllegalArgument() throws Exception {
         ResumableDownloader.download("http://localhost/file", tempDir().getAbsolutePath(), "..\\evil.bin",
                 CONNECT_TIMEOUT, READ_TIMEOUT);
     }
 
     @Test(expected = IOException.class)
-    public void unexpectedStatus_throws() throws Exception {
+    public void download_unexpectedStatus_throws() throws Exception {
         HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
         server.createContext("/file", exchange -> {
             exchange.sendResponseHeaders(404, -1);

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/update/ResumableDownloaderTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/update/ResumableDownloaderTest.java
@@ -232,6 +232,27 @@ public class ResumableDownloaderTest {
         }
     }
 
+    @Test
+    public void ensureSpace_sufficient_doesNotThrow() throws Exception {
+        File dir = tempDir();
+        try {
+            assertTrue("precondition: temp dir has free space", dir.getUsableSpace() > 1L);
+            // a real directory with far more than 1 byte free must pass without throwing
+            ResumableDownloader.ensureSpace(dir, 1L);
+        } finally {
+            deleteDir(dir);
+        }
+    }
+
+    @Test
+    public void ensureSpace_nullOrMissingDir_fallsBackToCwd() throws Exception {
+        // null and a non-existent directory both fall back to new File(".") (the working dir),
+        // so a modest requirement is satisfiable and must not throw.
+        assertTrue("precondition: working dir has free space", new File(".").getUsableSpace() > 1L);
+        ResumableDownloader.ensureSpace(null, 1L);
+        ResumableDownloader.ensureSpace(new File("no-such-dir-" + System.nanoTime()), 1L);
+    }
+
     // ---------------------------------------------------------------------
     // G8: target directory is created when missing
     // ---------------------------------------------------------------------

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/update/ResumableDownloaderTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/update/ResumableDownloaderTest.java
@@ -1,0 +1,430 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package io.mosip.registration.test.update;
+
+import com.sun.net.httpserver.HttpServer;
+import io.mosip.registration.update.ResumableDownloader;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Direct unit tests for {@link ResumableDownloader}. These exercise the class through its own
+ * {@code download(...)} entry point (not via {@code SoftwareUpdateUtil}) so the suite travels with the
+ * class when it is later moved into the launcher's shared module. The server is the JDK's built-in
+ * {@link HttpServer}, matching the style already used in {@code SoftwareUpdateUtilTest}.
+ */
+public class ResumableDownloaderTest {
+
+    private static final int CONNECT_TIMEOUT = 5000;
+    private static final int READ_TIMEOUT = 30000;
+    private static final int HTTP_RANGE_NOT_SATISFIABLE = 416;
+    private static final String ETAG = "\"v1-test-etag\"";
+    private static final String LAST_MODIFIED = "Wed, 21 Oct 2026 07:28:00 GMT";
+
+    // ---------------------------------------------------------------------
+    // Core happy paths (kept so the class is self-contained / portable)
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void fullDownload_success_cleansPartAndMeta() throws Exception {
+        byte[] payload = randomPayload(2000);
+        HttpServer server = rangeServer(payload, ETAG, null, true);
+        File dir = tempDir();
+        try {
+            ResumableDownloader.download(urlFor(server), dir.getAbsolutePath(), "artifact.bin",
+                    CONNECT_TIMEOUT, READ_TIMEOUT);
+
+            assertArrayEquals(payload, Files.readAllBytes(new File(dir, "artifact.bin").toPath()));
+            assertFalse(new File(dir, "artifact.bin.part").exists());
+            assertFalse(new File(dir, "artifact.bin.part.meta").exists());
+        } finally {
+            stop(server, dir);
+        }
+    }
+
+    @Test
+    public void resumesFromPartial_appends() throws Exception {
+        byte[] payload = randomPayload(2000);
+        HttpServer server = rangeServer(payload, ETAG, null, true);
+        File dir = tempDir();
+        try {
+            Files.write(new File(dir, "artifact.bin.part").toPath(), Arrays.copyOf(payload, 800));
+            writeMeta(dir, ETAG);
+
+            ResumableDownloader.download(urlFor(server), dir.getAbsolutePath(), "artifact.bin",
+                    CONNECT_TIMEOUT, READ_TIMEOUT);
+
+            assertArrayEquals(payload, Files.readAllBytes(new File(dir, "artifact.bin").toPath()));
+        } finally {
+            stop(server, dir);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // G1: 206 whose Content-Range start != expected offset -> discard + restart
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void resume206WithWrongStart_discardsAndRestarts() throws Exception {
+        byte[] payload = randomPayload(2000);
+        // Serves 206 but always claims it started at byte 0, regardless of the requested offset.
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/file", exchange -> {
+            exchange.getResponseHeaders().add("ETag", ETAG);
+            String range = exchange.getRequestHeaders().getFirst("Range");
+            if (range != null) {
+                exchange.getResponseHeaders().add("Content-Range", "bytes 0-9/" + payload.length);
+                exchange.sendResponseHeaders(206, 10);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(payload, 0, 10);
+                }
+            } else {
+                exchange.sendResponseHeaders(200, payload.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(payload);
+                }
+            }
+            exchange.close();
+        });
+        server.start();
+        File dir = tempDir();
+        try {
+            Files.write(new File(dir, "artifact.bin.part").toPath(), new byte[800]);
+            writeMeta(dir, ETAG);
+
+            ResumableDownloader.download(urlFor(server), dir.getAbsolutePath(), "artifact.bin",
+                    CONNECT_TIMEOUT, READ_TIMEOUT);
+
+            // bad 206 discarded, second attempt restarts clean from a 200 -> correct payload
+            assertArrayEquals(payload, Files.readAllBytes(new File(dir, "artifact.bin").toPath()));
+        } finally {
+            stop(server, dir);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // G2: 416 where the local part size != server total -> discard + restart fresh
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void rangeNotSatisfiable_partLargerThanTotal_restartsFresh() throws Exception {
+        byte[] payload = randomPayload(2000);
+        HttpServer server = rangeServer(payload, ETAG, null, true);
+        File dir = tempDir();
+        try {
+            // an over-sized (corrupt) part: Range start (2500) >= server size (2000) -> 416
+            Files.write(new File(dir, "artifact.bin.part").toPath(), new byte[2500]);
+            writeMeta(dir, ETAG);
+
+            ResumableDownloader.download(urlFor(server), dir.getAbsolutePath(), "artifact.bin",
+                    CONNECT_TIMEOUT, READ_TIMEOUT);
+
+            assertArrayEquals(payload, Files.readAllBytes(new File(dir, "artifact.bin").toPath()));
+        } finally {
+            stop(server, dir);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // G3 / G4: validator selection - weak ETag ignored, Last-Modified used
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void weakEtagIgnored_lastModifiedUsedAsValidator() throws Exception {
+        byte[] payload = randomPayload(4000);
+        // A weak ETag (W/...) is invalid for byte-range validation -> Last-Modified must be chosen.
+        HttpServer server = truncatingServer(payload, "W/\"weak\"", LAST_MODIFIED);
+        File dir = tempDir();
+        try {
+            expectIOException(server, dir);
+            // .part retained, and the persisted validator is the Last-Modified value (not the weak ETag)
+            assertEquals(LAST_MODIFIED, readMeta(dir));
+        } finally {
+            stop(server, dir);
+        }
+    }
+
+    @Test
+    public void noEtag_lastModifiedUsedAsValidator() throws Exception {
+        byte[] payload = randomPayload(4000);
+        HttpServer server = truncatingServer(payload, null, LAST_MODIFIED);
+        File dir = tempDir();
+        try {
+            expectIOException(server, dir);
+            assertEquals(LAST_MODIFIED, readMeta(dir));
+        } finally {
+            stop(server, dir);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // G5: no validator headers at all -> no .meta written (cannot resume next time)
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void noValidatorHeaders_metaNotWritten() throws Exception {
+        byte[] payload = randomPayload(4000);
+        HttpServer server = truncatingServer(payload, null, null);
+        File dir = tempDir();
+        try {
+            expectIOException(server, dir);
+            assertTrue("partial retained", new File(dir, "artifact.bin.part").exists());
+            assertFalse("no validator -> no meta", new File(dir, "artifact.bin.part.meta").exists());
+        } finally {
+            stop(server, dir);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // G6: unknown Content-Length (chunked) -> completeness check skipped, download still succeeds
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void chunkedUnknownLength_completes() throws Exception {
+        byte[] payload = randomPayload(2000);
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/file", exchange -> {
+            exchange.sendResponseHeaders(200, 0);   // 0 => chunked, length unknown to the client
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(payload);
+            }
+            exchange.close();
+        });
+        server.start();
+        File dir = tempDir();
+        try {
+            ResumableDownloader.download(urlFor(server), dir.getAbsolutePath(), "artifact.bin",
+                    CONNECT_TIMEOUT, READ_TIMEOUT);
+
+            assertArrayEquals(payload, Files.readAllBytes(new File(dir, "artifact.bin").toPath()));
+        } finally {
+            stop(server, dir);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // G7: insufficient disk space (public ensureSpace guard)
+    // ---------------------------------------------------------------------
+
+    @Test(expected = IOException.class)
+    public void ensureSpace_insufficient_throws() throws Exception {
+        File dir = tempDir();
+        try {
+            ResumableDownloader.ensureSpace(dir, Long.MAX_VALUE);
+        } finally {
+            deleteDir(dir);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // G8: target directory is created when missing
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void targetDirectoryCreatedWhenMissing() throws Exception {
+        byte[] payload = randomPayload(1000);
+        HttpServer server = rangeServer(payload, ETAG, null, true);
+        File base = tempDir();
+        File nested = new File(base, "a/b/c");
+        try {
+            assertFalse(nested.exists());
+
+            ResumableDownloader.download(urlFor(server), nested.getAbsolutePath(), "artifact.bin",
+                    CONNECT_TIMEOUT, READ_TIMEOUT);
+
+            assertArrayEquals(payload, Files.readAllBytes(new File(nested, "artifact.bin").toPath()));
+        } finally {
+            stop(server, base);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // G9: finalize overwrites an already-present target file
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void finalizeOverwritesExistingTarget() throws Exception {
+        byte[] payload = randomPayload(2000);
+        HttpServer server = rangeServer(payload, ETAG, null, true);
+        File dir = tempDir();
+        try {
+            Files.write(new File(dir, "artifact.bin").toPath(), "OLD-CONTENT".getBytes(StandardCharsets.UTF_8));
+
+            ResumableDownloader.download(urlFor(server), dir.getAbsolutePath(), "artifact.bin",
+                    CONNECT_TIMEOUT, READ_TIMEOUT);
+
+            assertArrayEquals(payload, Files.readAllBytes(new File(dir, "artifact.bin").toPath()));
+        } finally {
+            stop(server, dir);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // G10 + name guards + transport errors (direct on the class)
+    // ---------------------------------------------------------------------
+
+    @Test(expected = IllegalArgumentException.class)
+    public void blankFileName_rejected() throws Exception {
+        ResumableDownloader.download("http://localhost/file", tempDir().getAbsolutePath(), "",
+                CONNECT_TIMEOUT, READ_TIMEOUT);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void pathTraversalName_rejected() throws Exception {
+        ResumableDownloader.download("http://localhost/file", tempDir().getAbsolutePath(), "..\\evil.bin",
+                CONNECT_TIMEOUT, READ_TIMEOUT);
+    }
+
+    @Test(expected = IOException.class)
+    public void unexpectedStatus_throws() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/file", exchange -> {
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        });
+        server.start();
+        File dir = tempDir();
+        try {
+            ResumableDownloader.download(urlFor(server), dir.getAbsolutePath(), "artifact.bin",
+                    CONNECT_TIMEOUT, READ_TIMEOUT);
+        } finally {
+            stop(server, dir);
+        }
+    }
+
+    // ---- helpers ----
+
+    private static byte[] randomPayload(int size) {
+        byte[] bytes = new byte[size];
+        new Random(42).nextBytes(bytes);
+        return bytes;
+    }
+
+    private static File tempDir() throws IOException {
+        return Files.createTempDirectory("rdl").toFile();
+    }
+
+    private static String urlFor(HttpServer server) {
+        return "http://localhost:" + server.getAddress().getPort() + "/file";
+    }
+
+    private static void writeMeta(File dir, String validator) throws IOException {
+        Files.write(new File(dir, "artifact.bin.part.meta").toPath(), validator.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String readMeta(File dir) throws IOException {
+        return new String(Files.readAllBytes(new File(dir, "artifact.bin.part.meta").toPath()),
+                StandardCharsets.UTF_8).trim();
+    }
+
+    /** Runs a download that is expected to fail (truncated), asserting an IOException is raised. */
+    private static void expectIOException(HttpServer server, File dir) throws Exception {
+        try {
+            ResumableDownloader.download(urlFor(server), dir.getAbsolutePath(), "artifact.bin",
+                    CONNECT_TIMEOUT, READ_TIMEOUT);
+            org.junit.Assert.fail("expected IOException");
+        } catch (IOException expected) {
+            // expected
+        }
+    }
+
+    /** Serves the payload with the given validators, honouring Range (with If-Range) when {@code honorRange}. */
+    private static HttpServer rangeServer(byte[] payload, String etag, String lastModified, boolean honorRange)
+            throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/file", exchange -> {
+            if (etag != null) {
+                exchange.getResponseHeaders().add("ETag", etag);
+            }
+            if (lastModified != null) {
+                exchange.getResponseHeaders().add("Last-Modified", lastModified);
+            }
+            String range = exchange.getRequestHeaders().getFirst("Range");
+            String ifRange = exchange.getRequestHeaders().getFirst("If-Range");
+            boolean serveRange = honorRange && range != null && range.startsWith("bytes=")
+                    && (ifRange == null || etag == null || etag.equals(ifRange));
+            if (serveRange) {
+                long start = Long.parseLong(range.substring("bytes=".length()).split("-")[0]);
+                if (start >= payload.length) {
+                    exchange.getResponseHeaders().add("Content-Range", "bytes */" + payload.length);
+                    exchange.sendResponseHeaders(HTTP_RANGE_NOT_SATISFIABLE, -1);
+                    exchange.close();
+                    return;
+                }
+                int len = (int) (payload.length - start);
+                exchange.getResponseHeaders().add("Content-Range",
+                        "bytes " + start + "-" + (payload.length - 1) + "/" + payload.length);
+                exchange.sendResponseHeaders(206, len);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(payload, (int) start, len);
+                }
+            } else {
+                exchange.sendResponseHeaders(200, payload.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(payload);
+                }
+            }
+            exchange.close();
+        });
+        server.start();
+        return server;
+    }
+
+    /** Declares the full Content-Length but sends only half the body then closes (a truncated transfer). */
+    private static HttpServer truncatingServer(byte[] payload, String etag, String lastModified)
+            throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/file", exchange -> {
+            if (etag != null) {
+                exchange.getResponseHeaders().add("ETag", etag);
+            }
+            if (lastModified != null) {
+                exchange.getResponseHeaders().add("Last-Modified", lastModified);
+            }
+            exchange.sendResponseHeaders(200, payload.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(payload, 0, payload.length / 2);
+            }
+            exchange.close();
+        });
+        server.start();
+        return server;
+    }
+
+    private static void stop(HttpServer server, File dir) throws Exception {
+        server.stop(0);
+        deleteDir(dir);
+    }
+
+    private static void deleteDir(File dir) throws Exception {
+        if (dir != null && dir.exists()) {
+            File[] files = dir.listFiles();
+            if (files != null) {
+                for (File f : files) {
+                    if (f.isDirectory()) {
+                        deleteDir(f);
+                    } else {
+                        f.delete();
+                    }
+                }
+            }
+            dir.delete();
+        }
+    }
+}

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/update/ResumableDownloaderTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/update/ResumableDownloaderTest.java
@@ -142,6 +142,37 @@ public class ResumableDownloaderTest {
     }
 
     // ---------------------------------------------------------------------
+    // G2b: 416 where the local part size == server total -> finalize the local part (no re-download)
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void download_416PartMatchesTotal_finalizesLocalPart() throws Exception {
+        byte[] payload = randomPayload(2000);
+        // A complete .part exactly the server's size, but with distinguishable content so the
+        // assertion proves the local part is finalized as-is rather than re-downloaded. (finalize is
+        // completeness-based - length == server total; content integrity is verified downstream per
+        // the class contract.) The resume Range then starts at EOF (2000) -> the server answers 416,
+        // and because part length == server total handleRangeNotSatisfiable finalizes the part.
+        byte[] completePart = payload.clone();
+        completePart[0] ^= 0xFF;
+        HttpServer server = rangeServer(payload, ETAG, null, true);
+        File dir = tempDir();
+        try {
+            Files.write(new File(dir, "artifact.bin.part").toPath(), completePart);
+            writeMeta(dir, ETAG);
+
+            ResumableDownloader.download(urlFor(server), dir.getAbsolutePath(), "artifact.bin",
+                    CONNECT_TIMEOUT, READ_TIMEOUT);
+
+            assertArrayEquals(completePart, Files.readAllBytes(new File(dir, "artifact.bin").toPath()));
+            assertFalse(new File(dir, "artifact.bin.part").exists());       // part consumed by finalize
+            assertFalse(new File(dir, "artifact.bin.part.meta").exists());  // validator sidecar removed
+        } finally {
+            stop(server, dir);
+        }
+    }
+
+    // ---------------------------------------------------------------------
     // G3 / G4: validator selection - weak ETag ignored, Last-Modified used
     // ---------------------------------------------------------------------
 

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/update/SoftwareUpdateUtilTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/update/SoftwareUpdateUtilTest.java
@@ -1,13 +1,17 @@
 package io.mosip.registration.test.update;
 
+import com.sun.net.httpserver.HttpServer;
 import io.mosip.registration.exception.RegBaseCheckedException;
 import io.mosip.registration.update.SoftwareUpdateUtil;
 import org.junit.*;
 import org.mockito.InjectMocks;
 
 import java.io.*;
+import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Random;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -17,6 +21,9 @@ public class SoftwareUpdateUtilTest extends SoftwareUpdateUtil {
 
     private static final File LIB_DIR = new File("lib");
     private static final File TEMP_DIR = new File(".TEMP");
+
+    private static final int HTTP_RANGE_NOT_SATISFIABLE_TEST = 416;
+    private static final String SERVER_ETAG = "\"v1-test-etag\"";
 
     @InjectMocks
     private SoftwareUpdateUtil softwareUpdateUtil;
@@ -138,4 +145,246 @@ public class SoftwareUpdateUtilTest extends SoftwareUpdateUtil {
 
         assertFalse(temp.exists());
     }
+
+    // ---------------------------------------------------------------------
+    // downloadResumable(...) + ensureSpace(...) tests
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void downloadResumable_fullDownload_success() throws Exception {
+        byte[] payload = randomPayload(2000);
+        HttpServer server = startServer(payload, true);
+        File dir = Files.createTempDirectory("dl").toFile();
+        try {
+            downloadResumable(urlFor(server), dir.getAbsolutePath(), "artifact.bin");
+
+            File out = new File(dir, "artifact.bin");
+            assertTrue(out.exists());
+            assertArrayEquals(payload, Files.readAllBytes(out.toPath()));
+            assertFalse(new File(dir, "artifact.bin.part").exists());
+            assertFalse(new File(dir, "artifact.bin.part.meta").exists());
+        } finally {
+            server.stop(0);
+            deleteDir(dir);
+        }
+    }
+
+    @Test
+    public void downloadResumable_resumesFromPartial() throws Exception {
+        byte[] payload = randomPayload(2000);
+        HttpServer server = startServer(payload, true);
+        File dir = Files.createTempDirectory("dl").toFile();
+        try {
+            // pre-stage the first 800 bytes + the matching validator, as an interrupted attempt would
+            Files.write(new File(dir, "artifact.bin.part").toPath(), Arrays.copyOf(payload, 800));
+            writeMeta(dir, SERVER_ETAG);
+
+            downloadResumable(urlFor(server), dir.getAbsolutePath(), "artifact.bin");
+
+            assertArrayEquals(payload, Files.readAllBytes(new File(dir, "artifact.bin").toPath()));
+            assertFalse(new File(dir, "artifact.bin.part.meta").exists());
+        } finally {
+            server.stop(0);
+            deleteDir(dir);
+        }
+    }
+
+    @Test
+    public void downloadResumable_staleValidator_restartsFull_noSplice() throws Exception {
+        // Finding #1: a .part left from a PREVIOUS resource version must not be spliced onto the new one.
+        byte[] payload = randomPayload(2000);
+        HttpServer server = startServer(payload, true);
+        File dir = Files.createTempDirectory("dl").toFile();
+        try {
+            // partial of a different (old) version + an out-of-date validator
+            Files.write(new File(dir, "artifact.bin.part").toPath(), new byte[800]);
+            writeMeta(dir, "\"old-stale-etag\"");
+
+            downloadResumable(urlFor(server), dir.getAbsolutePath(), "artifact.bin");
+
+            // If-Range mismatch -> server sends 200 full -> file is the new payload, NOT old+new spliced
+            assertArrayEquals(payload, Files.readAllBytes(new File(dir, "artifact.bin").toPath()));
+        } finally {
+            server.stop(0);
+            deleteDir(dir);
+        }
+    }
+
+    @Test
+    public void downloadResumable_noValidator_restartsFull() throws Exception {
+        // A partial with no stored validator cannot be safely resumed -> discarded and re-downloaded.
+        byte[] payload = randomPayload(2000);
+        HttpServer server = startServer(payload, true);
+        File dir = Files.createTempDirectory("dl").toFile();
+        try {
+            Files.write(new File(dir, "artifact.bin.part").toPath(), new byte[1500]);
+            // no .part.meta written
+
+            downloadResumable(urlFor(server), dir.getAbsolutePath(), "artifact.bin");
+
+            assertArrayEquals(payload, Files.readAllBytes(new File(dir, "artifact.bin").toPath()));
+        } finally {
+            server.stop(0);
+            deleteDir(dir);
+        }
+    }
+
+    @Test
+    public void downloadResumable_serverIgnoresRange_restartsFromZero() throws Exception {
+        byte[] payload = randomPayload(2000);
+        HttpServer server = startServer(payload, false); // always 200, ignores Range
+        File dir = Files.createTempDirectory("dl").toFile();
+        try {
+            // stale partial; server ignores the Range and sends a full 200 -> must overwrite, not append
+            Files.write(new File(dir, "artifact.bin.part").toPath(), new byte[1500]);
+            writeMeta(dir, SERVER_ETAG);
+
+            downloadResumable(urlFor(server), dir.getAbsolutePath(), "artifact.bin");
+
+            assertArrayEquals(payload, Files.readAllBytes(new File(dir, "artifact.bin").toPath()));
+        } finally {
+            server.stop(0);
+            deleteDir(dir);
+        }
+    }
+
+    @Test
+    public void downloadResumable_rangeNotSatisfiable_finalizesExistingPart() throws Exception {
+        byte[] payload = randomPayload(2000);
+        HttpServer server = startServer(payload, true);
+        File dir = Files.createTempDirectory("dl").toFile();
+        try {
+            // part is already complete -> Range start == length -> server returns 416
+            File part = new File(dir, "artifact.bin.part");
+            Files.write(part.toPath(), payload);
+            writeMeta(dir, SERVER_ETAG);
+
+            downloadResumable(urlFor(server), dir.getAbsolutePath(), "artifact.bin");
+
+            assertArrayEquals(payload, Files.readAllBytes(new File(dir, "artifact.bin").toPath()));
+            assertFalse(part.exists());
+        } finally {
+            server.stop(0);
+            deleteDir(dir);
+        }
+    }
+
+    @Test
+    public void downloadResumable_truncatedResponse_throwsAndRetainsPart() throws Exception {
+        // Finding #2: a body shorter than the declared Content-Length must not be finalized as complete.
+        byte[] payload = randomPayload(4000);
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/file", exchange -> {
+            exchange.sendResponseHeaders(200, payload.length);   // declares full length...
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(payload, 0, payload.length / 2);        // ...but only sends half
+            }
+            exchange.close();
+        });
+        server.start();
+        File dir = Files.createTempDirectory("dl").toFile();
+        try {
+            try {
+                downloadResumable(urlFor(server), dir.getAbsolutePath(), "artifact.bin");
+                fail("expected RegBaseCheckedException for a truncated download");
+            } catch (RegBaseCheckedException expected) {
+                // expected
+            }
+            assertFalse("truncated file must not be finalized", new File(dir, "artifact.bin").exists());
+            assertTrue("partial must be retained for resume", new File(dir, "artifact.bin.part").exists());
+        } finally {
+            server.stop(0);
+            deleteDir(dir);
+        }
+    }
+
+    @Test(expected = RegBaseCheckedException.class)
+    public void downloadResumable_invalidHost_throws() throws Exception {
+        downloadResumable("http://invalid.invalid/file", TEMP_DIR.getAbsolutePath(), "x.bin");
+    }
+
+    @Test(expected = RegBaseCheckedException.class)
+    public void downloadResumable_unexpectedStatus_throws() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/file", exchange -> {
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        });
+        server.start();
+        File dir = Files.createTempDirectory("dl").toFile();
+        try {
+            downloadResumable(urlFor(server), dir.getAbsolutePath(), "x.bin");
+        } finally {
+            server.stop(0);
+            deleteDir(dir);
+        }
+    }
+
+    @Test
+    public void ensureSpace_sufficient_noException() throws Exception {
+        ensureSpace(TEMP_DIR, 1L);
+    }
+
+    @Test(expected = RegBaseCheckedException.class)
+    public void ensureSpace_insufficient_throws() throws Exception {
+        ensureSpace(TEMP_DIR, Long.MAX_VALUE);
+    }
+
+    @Test
+    public void ensureSpace_nullDir_usesCurrentDir_noException() throws Exception {
+        ensureSpace(null, 1L);
+    }
+
+    // ---- helpers ----
+
+    private static byte[] randomPayload(int size) {
+        byte[] bytes = new byte[size];
+        new Random(42).nextBytes(bytes);
+        return bytes;
+    }
+
+    private static void writeMeta(File dir, String validator) throws IOException {
+        Files.write(new File(dir, "artifact.bin.part.meta").toPath(), validator.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Serves the payload with an ETag validator, honouring Range only when If-Range matches that ETag. */
+    private static HttpServer startServer(byte[] payload, boolean honorRange) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/file", exchange -> {
+            exchange.getResponseHeaders().add("ETag", SERVER_ETAG);
+            String range = exchange.getRequestHeaders().getFirst("Range");
+            String ifRange = exchange.getRequestHeaders().getFirst("If-Range");
+            boolean serveRange = honorRange && range != null && range.startsWith("bytes=")
+                    && (ifRange == null || SERVER_ETAG.equals(ifRange));
+            if (serveRange) {
+                long start = Long.parseLong(range.substring("bytes=".length()).split("-")[0]);
+                if (start >= payload.length) {
+                    exchange.getResponseHeaders().add("Content-Range", "bytes */" + payload.length);
+                    exchange.sendResponseHeaders(HTTP_RANGE_NOT_SATISFIABLE_TEST, -1);
+                    exchange.close();
+                    return;
+                }
+                int len = (int) (payload.length - start);
+                exchange.getResponseHeaders().add("Content-Range",
+                        "bytes " + start + "-" + (payload.length - 1) + "/" + payload.length);
+                exchange.sendResponseHeaders(206, len);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(payload, (int) start, len);
+                }
+            } else {
+                exchange.sendResponseHeaders(200, payload.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(payload);
+                }
+            }
+            exchange.close();
+        });
+        server.start();
+        return server;
+    }
+
+    private static String urlFor(HttpServer server) {
+        return "http://localhost:" + server.getAddress().getPort() + "/file";
+    }
+
 }

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/update/SoftwareUpdateUtilTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/update/SoftwareUpdateUtilTest.java
@@ -303,6 +303,17 @@ public class SoftwareUpdateUtilTest extends SoftwareUpdateUtil {
         downloadResumable("http://invalid.invalid/file", TEMP_DIR.getAbsolutePath(), "x.bin");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void downloadResumable_pathTraversalName_rejected() throws Exception {
+        // A malicious manifest entry must not be able to write outside the target directory.
+        downloadResumable("http://localhost/file", TEMP_DIR.getAbsolutePath(), "..\\..\\evil.bin");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void downloadResumable_separatorInName_rejected() throws Exception {
+        downloadResumable("http://localhost/file", TEMP_DIR.getAbsolutePath(), "sub/evil.bin");
+    }
+
     @Test(expected = RegBaseCheckedException.class)
     public void downloadResumable_unexpectedStatus_throws() throws Exception {
         HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/update/SoftwareUpdateUtilTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/update/SoftwareUpdateUtilTest.java
@@ -147,7 +147,7 @@ public class SoftwareUpdateUtilTest extends SoftwareUpdateUtil {
     }
 
     // ---------------------------------------------------------------------
-    // downloadResumable(...) + ensureSpace(...) tests
+    // downloadResumable(...) tests
     // ---------------------------------------------------------------------
 
     @Test
@@ -329,21 +329,6 @@ public class SoftwareUpdateUtilTest extends SoftwareUpdateUtil {
             server.stop(0);
             deleteDir(dir);
         }
-    }
-
-    @Test
-    public void ensureSpace_sufficient_noException() throws Exception {
-        ensureSpace(TEMP_DIR, 1L);
-    }
-
-    @Test(expected = RegBaseCheckedException.class)
-    public void ensureSpace_insufficient_throws() throws Exception {
-        ensureSpace(TEMP_DIR, Long.MAX_VALUE);
-    }
-
-    @Test
-    public void ensureSpace_nullDir_usesCurrentDir_noException() throws Exception {
-        ensureSpace(null, 1L);
     }
 
     // ---- helpers ----

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/update/SoftwareUpdateUtilTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/update/SoftwareUpdateUtilTest.java
@@ -170,7 +170,7 @@ public class SoftwareUpdateUtilTest extends SoftwareUpdateUtil {
     }
 
     @Test
-    public void downloadResumable_resumesFromPartial() throws Exception {
+    public void downloadResumable_partialPresent_resumesByAppending() throws Exception {
         byte[] payload = randomPayload(2000);
         HttpServer server = startServer(payload, true);
         File dir = Files.createTempDirectory("dl").toFile();
@@ -299,7 +299,7 @@ public class SoftwareUpdateUtilTest extends SoftwareUpdateUtil {
     }
 
     @Test(expected = RegBaseCheckedException.class)
-    public void downloadResumable_invalidHost_throws() throws Exception {
+    public void downloadResumable_invalidHost_throwsException() throws Exception {
         downloadResumable("http://invalid.invalid/file", TEMP_DIR.getAbsolutePath(), "x.bin");
     }
 
@@ -315,7 +315,7 @@ public class SoftwareUpdateUtilTest extends SoftwareUpdateUtil {
     }
 
     @Test(expected = RegBaseCheckedException.class)
-    public void downloadResumable_unexpectedStatus_throws() throws Exception {
+    public void downloadResumable_unexpectedStatus_throwsException() throws Exception {
         HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
         server.createContext("/file", exchange -> {
             exchange.sendResponseHeaders(404, -1);


### PR DESCRIPTION
Refer Story #807 
Fixes #808 

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Software updates now support resumable downloads—interrupted transfers can resume from the last point instead of restarting completely. Failed attempts retain partial downloads for subsequent resumption.
  * Disk space is automatically verified before downloads commence to prevent failures due to storage limitations.
  * Enhanced integrity validation ensures downloaded files are complete and uncorrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resumable download support for update artifacts with safe staging/finalization and sidecar metadata.
  * Software update jar handling (v1.3.0+) now records missing/checksum-invalid artifacts without clearing the artifacts area, enabling resume.
  * Added disk-space checks and configurable connection/read timeouts for resumable downloads.

* **Bug Fixes**
  * Improved recovery for stale/invalid resume data (including 206/416 cases), servers ignoring Range, and truncated responses (throws while retaining partials).

* **Tests**
  * Added end-to-end tests covering resume, restart/discard behavior, edge cases, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->