### PR TITLE
T5 (#812): build-pipeline dual manifest + detached signatures

### DIFF
--- a/registration/configure.sh
+++ b/registration/configure.sh
@@ -118,7 +118,37 @@ cp "${work_dir}"/registration-client/target/run.bat "${work_dir}"/registration-c
 jarsigner -keystore "${work_dir}"/build_files/keystore.p12 -storepass ${keystore_secret} -tsa ${signer_timestamp_url_env} -digestalg SHA-256 "${work_dir}"/registration-client/target/lib/registration-client-${client_version_env}.jar CodeSigning
 jarsigner -keystore "${work_dir}"/build_files/keystore.p12 -storepass ${keystore_secret} -tsa ${signer_timestamp_url_env} -digestalg SHA-256 "${work_dir}"/registration-client/target/lib/registration-services-${client_version_env}.jar CodeSigning
 
-java -cp "${work_dir}"/registration-client/target/registration-client-${client_version_env}.jar:"${work_dir}"/registration-client/target/lib/* io.mosip.registration.update.ManifestCreator "${client_version_env}" "${work_dir}/registration-client/target/lib" "${work_dir}/registration-client/target"
+# ----------------------------------------------------------------------------------------------
+# 1.3.0 dual manifest + detached SHA256withRSA signatures (issue #812).
+# Verified at runtime by the launcher's SignatureVerifier using the public key in provider.pem
+# (the cert of the same CodeSigning keypair in keystore.p12).
+# ----------------------------------------------------------------------------------------------
+keystore="${work_dir}/build_files/keystore.p12"
+signing_alias="CodeSigning"
+target_dir="${work_dir}/registration-client/target"
+java_cp="${target_dir}/registration-client-${client_version_env}.jar:${target_dir}/lib/*"
+
+# lib/MANIFEST.MF : per-file integrity hashes of everything under lib/ (bundled inside lib.zip)
+java -cp "${java_cp}" io.mosip.registration.update.ManifestCreator "${client_version_env}" "${target_dir}/lib" "${target_dir}/lib"
+java -cp "${java_cp}" io.mosip.registration.update.ManifestSigner "${keystore}" "${keystore_secret}" "${signing_alias}" "${target_dir}/lib/MANIFEST.MF" "${target_dir}/lib/MANIFEST.MF.sig"
+
+# jre21.zip : the JRE artifact referenced by the root manifest / downloaded by the launcher
+cd "${target_dir}"
+/usr/bin/zip -r jre21.zip jre
+
+# Root ./MANIFEST.MF : orchestration artifacts only (NO lib.zip entry). Tolerant of sibling 1.3.0
+# artifacts (_launcher.jar / migration.exe / rollback.exe) that may not exist yet -- those entries
+# are skipped with a warning and fill in automatically as T2/T3/T4 land.
+java -cp "${java_cp}" io.mosip.registration.update.ManifestCreator --list "${client_version_env}" "${target_dir}" \
+  "${target_dir}/jre21.zip" \
+  "${target_dir}/_launcher.jar" \
+  "${target_dir}/migration.exe" \
+  "${target_dir}/rollback.exe" \
+  "${target_dir}/run.bat"
+java -cp "${java_cp}" io.mosip.registration.update.ManifestSigner "${keystore}" "${keystore_secret}" "${signing_alias}" "${target_dir}/MANIFEST.MF" "${target_dir}/MANIFEST.MF.sig"
+
+# lib.zip : all of lib/** (including the signed lib/MANIFEST.MF) hosted from the upgrade server
+/usr/bin/zip -r lib.zip lib
 
 cd "${work_dir}"/registration-client/target/
 
@@ -154,6 +184,9 @@ mkdir -p /var/www/html/registration-test/${client_version_env}
  
 cp "${work_dir}"/registration-client/target/lib/* /var/www/html/registration-client/${client_version_env}/lib
 cp "${work_dir}"/registration-client/target/MANIFEST.MF /var/www/html/registration-client/${client_version_env}/
+cp "${work_dir}"/registration-client/target/MANIFEST.MF.sig /var/www/html/registration-client/${client_version_env}/
+cp "${work_dir}"/registration-client/target/lib.zip /var/www/html/registration-client/${client_version_env}/
+cp "${work_dir}"/registration-client/target/jre21.zip /var/www/html/registration-client/${client_version_env}/
 cp "${work_dir}"/build_files/maven-metadata.xml /var/www/html/registration-client/
 cp "${work_dir}"/registration-client/target/reg-client.zip /var/www/html/registration-client/${client_version_env}/
 cp "${work_dir}"/registration-test-utility.zip /var/www/html/registration-client/${client_version_env}/

--- a/registration/configure.sh
+++ b/registration/configure.sh
@@ -39,6 +39,17 @@ rm ${work_dir}/registration-client/target/lib/provider.pem
 
 cd "${work_dir}"
 
+# ----------------------------------------------------------------------------------------------
+# SECURITY : snapshot a TRUSTED classpath for the build-time signing tools NOW, while
+# target/lib still contains ONLY the maven-built project jar + its resolved dependencies. The blocks
+# below copy externally-downloaded / operator-supplied jars (third-party SDK, custom impls,
+# registration-api-impl, icu4j, clamav) into target/lib. Running ManifestCreator / ManifestSigner off
+# the full "lib/*" wildcard would let one of those untrusted jars shadow a tool class (or one of its
+# dependency classes) and execute during signing with access to the keystore secret. ManifestCreator
+# reads target/lib only as DATA (to hash it), so the tools never need those jars on their classpath.
+trusted_tools_cp="$(ls "${work_dir}"/registration-client/target/lib/*.jar | tr '\n' ':')"
+trusted_tools_cp="${trusted_tools_cp%:}"
+
 if wget "${artifactory_url}/artifactory/libs-release-local/reg-client/resources.zip"
 then
   echo "Successfully downloaded reg-client resources, Adding it to reg-client jar"
@@ -126,7 +137,10 @@ jarsigner -keystore "${work_dir}"/build_files/keystore.p12 -storepass ${keystore
 keystore="${work_dir}/build_files/keystore.p12"
 signing_alias="CodeSigning"
 target_dir="${work_dir}/registration-client/target"
-java_cp="${target_dir}/registration-client-${client_version_env}.jar:${target_dir}/lib/*"
+# Trusted, external-jar-free classpath snapshotted above (see SECURITY note before the downloads).
+# Do NOT use "${target_dir}/lib/*" here: by this point lib/ also holds downloaded / operator-supplied
+# jars that must never be on the signing-tool classpath.
+java_cp="${trusted_tools_cp}"
 
 # lib/MANIFEST.MF : per-file integrity hashes of everything under lib/ (bundled inside lib.zip)
 # ManifestSigner reads the keystore password from the keystore_secret_env env var (not argv) so the

--- a/registration/configure.sh
+++ b/registration/configure.sh
@@ -129,8 +129,10 @@ target_dir="${work_dir}/registration-client/target"
 java_cp="${target_dir}/registration-client-${client_version_env}.jar:${target_dir}/lib/*"
 
 # lib/MANIFEST.MF : per-file integrity hashes of everything under lib/ (bundled inside lib.zip)
+# ManifestSigner reads the keystore password from the keystore_secret_env env var (not argv) so the
+# secret never appears in process listings.
 java -cp "${java_cp}" io.mosip.registration.update.ManifestCreator "${client_version_env}" "${target_dir}/lib" "${target_dir}/lib"
-java -cp "${java_cp}" io.mosip.registration.update.ManifestSigner "${keystore}" "${keystore_secret}" "${signing_alias}" "${target_dir}/lib/MANIFEST.MF" "${target_dir}/lib/MANIFEST.MF.sig"
+java -cp "${java_cp}" io.mosip.registration.update.ManifestSigner "${keystore}" "${signing_alias}" "${target_dir}/lib/MANIFEST.MF" "${target_dir}/lib/MANIFEST.MF.sig"
 
 # jre21.zip : the JRE artifact referenced by the root manifest / downloaded by the launcher
 cd "${target_dir}"
@@ -145,7 +147,7 @@ java -cp "${java_cp}" io.mosip.registration.update.ManifestCreator --list "${cli
   "${target_dir}/migration.exe" \
   "${target_dir}/rollback.exe" \
   "${target_dir}/run.bat"
-java -cp "${java_cp}" io.mosip.registration.update.ManifestSigner "${keystore}" "${keystore_secret}" "${signing_alias}" "${target_dir}/MANIFEST.MF" "${target_dir}/MANIFEST.MF.sig"
+java -cp "${java_cp}" io.mosip.registration.update.ManifestSigner "${keystore}" "${signing_alias}" "${target_dir}/MANIFEST.MF" "${target_dir}/MANIFEST.MF.sig"
 
 # lib.zip : all of lib/** (including the signed lib/MANIFEST.MF) hosted from the upgrade server
 /usr/bin/zip -r lib.zip lib

--- a/registration/registration-services/src/main/java/io/mosip/registration/update/ManifestCreator.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/ManifestCreator.java
@@ -7,6 +7,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -14,31 +17,78 @@ public class ManifestCreator {
 
     private static final Logger logger = LoggerFactory.getLogger(ManifestCreator.class);
     private static final String MANIFEST_FILE_NAME = "MANIFEST.MF";
-
-    private static final Manifest manifest = new Manifest();
+    private static final String LIST_MODE = "--list";
 
     public static void main(String[] args) {
-        String version = args[0];
-        String libraryFolderPath = args[1];
-        String targetPath = args[2];
-
         try {
-            File libFolder = new File(libraryFolderPath);
-            if(libFolder.exists() && libFolder.isDirectory()) {
-                manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, version);
-                for(File file : libFolder.listFiles()) {
-                    addEntryInManifest(file);
+            if (args.length > 0 && LIST_MODE.equals(args[0])) {
+                // --list <version> <targetPath> <file1> [<file2> ...]
+                // Builds the root MANIFEST.MF over an explicit, tolerant set of orchestration
+                // artifacts (jre21.zip, _launcher.jar, migration.exe, rollback.exe, run.bat).
+                // Files that do not exist yet (e.g. artifacts produced by other 1.3.0 sub-tasks)
+                // are skipped with a warning rather than failing the build.
+                String version = args[1];
+                String targetPath = args[2];
+                List<File> files = new ArrayList<>();
+                for (String path : Arrays.asList(args).subList(3, args.length)) {
+                    files.add(new File(path));
                 }
-                manifest.write(new FileOutputStream(targetPath + File.separator + MANIFEST_FILE_NAME));
-                System.out.println("Created " + MANIFEST_FILE_NAME);
+                createFromFiles(version, new File(targetPath, MANIFEST_FILE_NAME), files);
+            } else {
+                // <version> <libraryFolderPath> <targetPath>
+                String version = args[0];
+                String libraryFolderPath = args[1];
+                String targetPath = args[2];
+                createFromFolder(version, new File(libraryFolderPath), new File(targetPath, MANIFEST_FILE_NAME));
             }
-
         } catch (Throwable e) {
             logger.error("Failed to create the manifest", e);
         }
     }
 
-    private static void addEntryInManifest(File file) throws Exception {
+    /**
+     * Builds a manifest containing one entry per file in {@code libFolder} (per-file integrity
+     * hashes). Used for {@code lib/MANIFEST.MF}, which is bundled inside {@code lib.zip}.
+     */
+    static void createFromFolder(String version, File libFolder, File targetFile) throws Exception {
+        if (!(libFolder.exists() && libFolder.isDirectory())) {
+            logger.error("Library folder does not exist or is not a directory: {}", libFolder);
+            return;
+        }
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, version);
+        for (File file : libFolder.listFiles()) {
+            addEntryInManifest(manifest, file);
+        }
+        write(manifest, targetFile);
+    }
+
+    /**
+     * Builds a manifest over an explicit list of files, tolerating files that are absent (logged and
+     * skipped). Used for the root {@code ./MANIFEST.MF}, whose orchestration artifacts may be
+     * produced by other 1.3.0 sub-tasks and not present at the time this runs.
+     */
+    static void createFromFiles(String version, File targetFile, List<File> files) throws Exception {
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, version);
+        for (File file : files) {
+            if (file.exists() && file.isFile()) {
+                addEntryInManifest(manifest, file);
+            } else {
+                logger.warn("Skipping manifest entry, file not present yet: {}", file.getName());
+            }
+        }
+        write(manifest, targetFile);
+    }
+
+    private static void write(Manifest manifest, File targetFile) throws Exception {
+        try (FileOutputStream out = new FileOutputStream(targetFile)) {
+            manifest.write(out);
+        }
+        logger.info("Created {} ({} entries)", targetFile.getPath(), manifest.getEntries().size());
+    }
+
+    private static void addEntryInManifest(Manifest manifest, File file) throws Exception {
         String hashText = HMACUtils2.digestAsPlainText(FileUtils.readFileToByteArray(file));
         Attributes attribute = new Attributes();
         attribute.put(Attributes.Name.CONTENT_TYPE, hashText);

--- a/registration/registration-services/src/main/java/io/mosip/registration/update/ManifestCreator.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/ManifestCreator.java
@@ -21,12 +21,19 @@ public class ManifestCreator {
 
     public static void main(String[] args) {
         try {
-            if (args.length > 0 && LIST_MODE.equals(args[0])) {
+            if (args.length == 0) {
+                throw new IllegalArgumentException(
+                        "Usage: [--list <version> <targetPath> <file1> ...] OR <version> <libraryFolderPath> <targetPath>");
+            }
+            if (LIST_MODE.equals(args[0])) {
                 // --list <version> <targetPath> <file1> [<file2> ...]
                 // Builds the root MANIFEST.MF over an explicit, tolerant set of orchestration
                 // artifacts (jre21.zip, _launcher.jar, migration.exe, rollback.exe, run.bat).
                 // Files that do not exist yet (e.g. artifacts produced by other 1.3.0 sub-tasks)
                 // are skipped with a warning rather than failing the build.
+                if (args.length < 4) {
+                    throw new IllegalArgumentException("Usage: --list <version> <targetPath> <file1> [<file2> ...]");
+                }
                 String version = args[1];
                 String targetPath = args[2];
                 List<File> files = new ArrayList<>();
@@ -36,13 +43,20 @@ public class ManifestCreator {
                 createFromFiles(version, new File(targetPath, MANIFEST_FILE_NAME), files);
             } else {
                 // <version> <libraryFolderPath> <targetPath>
+                if (args.length != 3) {
+                    throw new IllegalArgumentException("Usage: <version> <libraryFolderPath> <targetPath>");
+                }
                 String version = args[0];
                 String libraryFolderPath = args[1];
                 String targetPath = args[2];
                 createFromFolder(version, new File(libraryFolderPath), new File(targetPath, MANIFEST_FILE_NAME));
             }
-        } catch (Throwable e) {
+        } catch (Exception e) {
+            // Fail loudly with a non-zero exit so configure.sh (set -e) aborts the build instead of
+            // continuing to sign/package a stale or missing MANIFEST.MF. Errors (not Exceptions) are
+            // left to propagate uncaught — the JVM still exits non-zero, so the build still aborts.
             logger.error("Failed to create the manifest", e);
+            System.exit(1);
         }
     }
 
@@ -52,13 +66,22 @@ public class ManifestCreator {
      */
     static void createFromFolder(String version, File libFolder, File targetFile) throws Exception {
         if (!(libFolder.exists() && libFolder.isDirectory())) {
-            logger.error("Library folder does not exist or is not a directory: {}", libFolder);
-            return;
+            // Throw (not return) so main() exits non-zero and configure.sh (set -e) aborts at the real
+            // cause, rather than continuing to sign a MANIFEST.MF that was never written.
+            throw new IllegalStateException("Library folder does not exist or is not a directory: " + libFolder);
         }
         Manifest manifest = new Manifest();
         manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, version);
-        for (File file : libFolder.listFiles()) {
-            addEntryInManifest(manifest, file);
+        File[] children = libFolder.listFiles();
+        if (children == null) {
+            throw new IllegalStateException("Unable to list files in " + libFolder.getPath());
+        }
+        for (File file : children) {
+            if (file.isFile()) {
+                addEntryInManifest(manifest, file);
+            } else {
+                logger.warn("Skipping non-regular file in manifest folder: {}", file.getName());
+            }
         }
         write(manifest, targetFile);
     }

--- a/registration/registration-services/src/main/java/io/mosip/registration/update/ManifestCreator.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/ManifestCreator.java
@@ -1,12 +1,15 @@
 package io.mosip.registration.update;
 
-import io.mosip.kernel.core.util.FileUtils;
 import io.mosip.kernel.core.util.HMACUtils2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -112,9 +115,27 @@ public class ManifestCreator {
     }
 
     private static void addEntryInManifest(Manifest manifest, File file) throws Exception {
-        String hashText = HMACUtils2.digestAsPlainText(FileUtils.readFileToByteArray(file));
+        // Stream the file through SHA-256 rather than buffering it whole (jre21.zip is hundreds of MB).
+        // The result is byte-for-byte identical to HMACUtils2.digestAsPlainText(readFileToByteArray(file)):
+        // generateHash() is a SHA-256 MessageDigest.digest(), and digestAsPlainText formats it as
+        // encodeBytesToHex(digest, true /*upper-case*/, BIG_ENDIAN) — reused verbatim here so the
+        // manifest hashes stay compatible with the launcher's verifier and validateJarChecksum().
+        String hashText = HMACUtils2.encodeBytesToHex(sha256(file), true, ByteOrder.BIG_ENDIAN);
         Attributes attribute = new Attributes();
         attribute.put(Attributes.Name.CONTENT_TYPE, hashText);
         manifest.getEntries().put(file.getName(), attribute);
+    }
+
+    /** Computes the SHA-256 digest of {@code file} by streaming it from disk (no full-file buffering). */
+    private static byte[] sha256(File file) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        try (InputStream in = Files.newInputStream(file.toPath())) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+        }
+        return digest.digest();
     }
 }

--- a/registration/registration-services/src/main/java/io/mosip/registration/update/ManifestSigner.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/ManifestSigner.java
@@ -1,0 +1,81 @@
+package io.mosip.registration.update;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.Signature;
+
+/**
+ * Build-time signer that produces the detached {@code MANIFEST.MF.sig} files introduced in 1.3.0
+ * (issue #812). Signatures are {@code SHA256withRSA} over the raw manifest bytes, created with the
+ * existing code-signing key from {@code keystore.p12} &mdash; the same keypair whose certificate is
+ * shipped as {@code provider.pem} and used by the launcher's {@code SignatureVerifier} to verify.
+ * <p>
+ * Reads the private key straight out of the PKCS#12 keystore so the build never has to extract it to
+ * disk. Invoked from {@code configure.sh} via {@code java -cp ... io.mosip.registration.update.ManifestSigner}.
+ */
+public final class ManifestSigner {
+
+    private static final Logger logger = LoggerFactory.getLogger(ManifestSigner.class);
+    private static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
+    private static final String KEYSTORE_TYPE = "PKCS12";
+
+    private ManifestSigner() {
+        // utility class
+    }
+
+    /**
+     * CLI entry point.
+     *
+     * @param args {@code <keystorePath> <storePass> <alias> <dataFile> <sigFile>}
+     */
+    public static void main(String[] args) {
+        if (args.length != 5) {
+            logger.error("Usage: ManifestSigner <keystorePath> <storePass> <alias> <dataFile> <sigFile>");
+            System.exit(2);
+        }
+        try {
+            PrivateKey privateKey = loadPrivateKey(new File(args[0]), args[1].toCharArray(), args[2]);
+            signFile(new File(args[3]), new File(args[4]), privateKey);
+            logger.info("Signed {} -> {}", args[3], args[4]);
+        } catch (Exception e) {
+            logger.error("Failed to sign {}", args[3], e);
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Loads the private key for {@code alias} from a PKCS#12 keystore, using the store password as the
+     * key password (the convention for the registration-client {@code keystore.p12}).
+     */
+    public static PrivateKey loadPrivateKey(File keystoreFile, char[] storePass, String alias) throws Exception {
+        KeyStore keyStore = KeyStore.getInstance(KEYSTORE_TYPE);
+        try (FileInputStream in = new FileInputStream(keystoreFile)) {
+            keyStore.load(in, storePass);
+        }
+        PrivateKey privateKey = (PrivateKey) keyStore.getKey(alias, storePass);
+        if (privateKey == null) {
+            throw new IllegalArgumentException("No private key found for alias: " + alias);
+        }
+        return privateKey;
+    }
+
+    /** Writes a detached signature of {@code dataFile} to {@code sigFile}. */
+    public static void signFile(File dataFile, File sigFile, PrivateKey privateKey) throws Exception {
+        byte[] signature = sign(Files.readAllBytes(dataFile.toPath()), privateKey);
+        Files.write(sigFile.toPath(), signature);
+    }
+
+    /** Produces a detached {@code SHA256withRSA} signature over {@code data}. */
+    public static byte[] sign(byte[] data, PrivateKey privateKey) throws Exception {
+        Signature signer = Signature.getInstance(SIGNATURE_ALGORITHM);
+        signer.initSign(privateKey);
+        signer.update(data);
+        return signer.sign();
+    }
+}

--- a/registration/registration-services/src/main/java/io/mosip/registration/update/ManifestSigner.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/ManifestSigner.java
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 package io.mosip.registration.update;
 
 import org.slf4j.Logger;

--- a/registration/registration-services/src/main/java/io/mosip/registration/update/ManifestSigner.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/update/ManifestSigner.java
@@ -24,27 +24,40 @@ public final class ManifestSigner {
     private static final Logger logger = LoggerFactory.getLogger(ManifestSigner.class);
     private static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
     private static final String KEYSTORE_TYPE = "PKCS12";
+    /**
+     * Environment variable carrying the keystore password. Read from the environment rather than a
+     * command-line argument so the secret is never exposed in process listings (ps, proc cmdline).
+     * Already present in the build container as a Dockerfile {@code ENV} and inherited by this process.
+     */
+    private static final String STORE_PASS_ENV_VAR = "keystore_secret_env";
 
     private ManifestSigner() {
         // utility class
     }
 
     /**
-     * CLI entry point.
+     * CLI entry point. The keystore password is read from the {@code keystore_secret_env} environment
+     * variable (NOT a command-line argument), so it is never exposed in process listings.
      *
-     * @param args {@code <keystorePath> <storePass> <alias> <dataFile> <sigFile>}
+     * @param args {@code <keystorePath> <alias> <dataFile> <sigFile>}
      */
     public static void main(String[] args) {
-        if (args.length != 5) {
-            logger.error("Usage: ManifestSigner <keystorePath> <storePass> <alias> <dataFile> <sigFile>");
+        if (args.length != 4) {
+            logger.error("Usage: ManifestSigner <keystorePath> <alias> <dataFile> <sigFile> "
+                    + "(keystore password is read from the {} environment variable)", STORE_PASS_ENV_VAR);
+            System.exit(2);
+        }
+        String storePass = System.getenv(STORE_PASS_ENV_VAR);
+        if (storePass == null || storePass.isEmpty()) {
+            logger.error("Keystore password not provided: set the {} environment variable", STORE_PASS_ENV_VAR);
             System.exit(2);
         }
         try {
-            PrivateKey privateKey = loadPrivateKey(new File(args[0]), args[1].toCharArray(), args[2]);
-            signFile(new File(args[3]), new File(args[4]), privateKey);
-            logger.info("Signed {} -> {}", args[3], args[4]);
+            PrivateKey privateKey = loadPrivateKey(new File(args[0]), storePass.toCharArray(), args[1]);
+            signFile(new File(args[2]), new File(args[3]), privateKey);
+            logger.info("Signed {} -> {}", args[2], args[3]);
         } catch (Exception e) {
-            logger.error("Failed to sign {}", args[3], e);
+            logger.error("Failed to sign {}", args[2], e);
             System.exit(1);
         }
     }

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/update/ManifestCreatorTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/update/ManifestCreatorTest.java
@@ -68,7 +68,7 @@ public class ManifestCreatorTest extends ManifestCreator {
 
 
     @Test
-    public void listModeCreatesManifestFromExplicitFiles() throws Exception {
+    public void listMode_explicitFiles_createsManifest() throws Exception {
         listModeTempDir = Files.createTempDirectory("manifest-list-mode").toFile();
         File jre = new File(listModeTempDir, "jre21.zip");
         File runBat = new File(listModeTempDir, "run.bat");
@@ -92,7 +92,7 @@ public class ManifestCreatorTest extends ManifestCreator {
     }
 
     @Test
-    public void listModeSkipsMissingFiles() throws Exception {
+    public void listMode_missingFile_skipsMissing() throws Exception {
         listModeTempDir = Files.createTempDirectory("manifest-list-mode-missing").toFile();
         File present = new File(listModeTempDir, "run.bat");
         Files.write(present.toPath(), "run-bytes".getBytes(StandardCharsets.UTF_8));
@@ -113,7 +113,7 @@ public class ManifestCreatorTest extends ManifestCreator {
     }
 
     @Test
-    public void streamedHashMatchesDigestAsPlainText() throws Exception {
+    public void listMode_largeFile_hashMatchesDigestAsPlainText() throws Exception {
         listModeTempDir = Files.createTempDirectory("manifest-hash-compat").toFile();
         File big = new File(listModeTempDir, "jre21.zip");
         // larger than the 8 KB streaming buffer, to exercise multi-chunk digest updates

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/update/ManifestCreatorTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/update/ManifestCreatorTest.java
@@ -4,6 +4,7 @@ import io.mosip.kernel.core.util.FileUtils;
 import io.mosip.registration.update.ClientIntegrityValidator;
 import io.mosip.registration.update.ClientSetupValidator;
 import io.mosip.registration.update.ManifestCreator;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,6 +14,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.cert.X509Certificate;
 import java.util.jar.Attributes;
@@ -24,6 +27,18 @@ import java.util.jar.Manifest;
 public class ManifestCreatorTest extends ManifestCreator {
 
     private static final String MANIFEST_FILE_NAME = "MANIFEST.MF";
+
+    private File listModeTempDir;
+
+    @After
+    public void cleanUpListMode() throws IOException {
+        if (listModeTempDir != null && listModeTempDir.exists()) {
+            for (File f : listModeTempDir.listFiles()) {
+                Files.deleteIfExists(f.toPath());
+            }
+            Files.deleteIfExists(listModeTempDir.toPath());
+        }
+    }
 
     @Test
     public void mainTest() throws Exception {
@@ -51,6 +66,51 @@ public class ManifestCreatorTest extends ManifestCreator {
         Assert.assertFalse(failed);
     }
 
+
+    @Test
+    public void listModeCreatesManifestFromExplicitFiles() throws Exception {
+        listModeTempDir = Files.createTempDirectory("manifest-list-mode").toFile();
+        File jre = new File(listModeTempDir, "jre21.zip");
+        File runBat = new File(listModeTempDir, "run.bat");
+        Files.write(jre.toPath(), "jre-bytes".getBytes(StandardCharsets.UTF_8));
+        Files.write(runBat.toPath(), "run-bytes".getBytes(StandardCharsets.UTF_8));
+
+        String version = "1.3.0";
+        main(new String[]{"--list", version, listModeTempDir.getPath(), jre.getPath(), runBat.getPath()});
+
+        File manifestFile = new File(listModeTempDir, MANIFEST_FILE_NAME);
+        Assert.assertTrue(manifestFile.exists());
+        Manifest manifest;
+        try (FileInputStream in = new FileInputStream(manifestFile)) {
+            manifest = new Manifest(in);
+        }
+        Assert.assertEquals(version, manifest.getMainAttributes().getValue(Attributes.Name.MANIFEST_VERSION));
+        Assert.assertEquals(2, manifest.getEntries().size());
+        Assert.assertTrue(manifest.getEntries().containsKey("jre21.zip"));
+        Assert.assertTrue(manifest.getEntries().containsKey("run.bat"));
+        Assert.assertNotNull(manifest.getEntries().get("jre21.zip").getValue(Attributes.Name.CONTENT_TYPE));
+    }
+
+    @Test
+    public void listModeSkipsMissingFiles() throws Exception {
+        listModeTempDir = Files.createTempDirectory("manifest-list-mode-missing").toFile();
+        File present = new File(listModeTempDir, "run.bat");
+        Files.write(present.toPath(), "run-bytes".getBytes(StandardCharsets.UTF_8));
+        File missing = new File(listModeTempDir, "_launcher.jar"); // never created (produced later by T2)
+
+        String version = "1.3.0";
+        main(new String[]{"--list", version, listModeTempDir.getPath(), present.getPath(), missing.getPath()});
+
+        File manifestFile = new File(listModeTempDir, MANIFEST_FILE_NAME);
+        Assert.assertTrue(manifestFile.exists());
+        Manifest manifest;
+        try (FileInputStream in = new FileInputStream(manifestFile)) {
+            manifest = new Manifest(in);
+        }
+        Assert.assertEquals(1, manifest.getEntries().size());
+        Assert.assertTrue(manifest.getEntries().containsKey("run.bat"));
+        Assert.assertFalse(manifest.getEntries().containsKey("_launcher.jar"));
+    }
 
     @Test
     public void integrityCheckTest() throws IOException {

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/update/ManifestCreatorTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/update/ManifestCreatorTest.java
@@ -113,6 +113,27 @@ public class ManifestCreatorTest extends ManifestCreator {
     }
 
     @Test
+    public void streamedHashMatchesDigestAsPlainText() throws Exception {
+        listModeTempDir = Files.createTempDirectory("manifest-hash-compat").toFile();
+        File big = new File(listModeTempDir, "jre21.zip");
+        // larger than the 8 KB streaming buffer, to exercise multi-chunk digest updates
+        byte[] payload = new byte[20000];
+        new java.util.Random(42).nextBytes(payload);
+        Files.write(big.toPath(), payload);
+
+        main(new String[]{"--list", "1.3.0", listModeTempDir.getPath(), big.getPath()});
+
+        Manifest manifest;
+        try (FileInputStream in = new FileInputStream(new File(listModeTempDir, MANIFEST_FILE_NAME))) {
+            manifest = new Manifest(in);
+        }
+        String streamed = manifest.getEntries().get("jre21.zip").getValue(Attributes.Name.CONTENT_TYPE);
+        // streaming the file must yield the exact same value as hashing the whole byte[] the old way
+        String expected = io.mosip.kernel.core.util.HMACUtils2.digestAsPlainText(payload);
+        Assert.assertEquals(expected, streamed);
+    }
+
+    @Test
     public void integrityCheckTest() throws IOException {
         URL url = ManifestCreatorTest.class.getResource("/setup/registration-api-1.3.0-SNAPSHOT.jar");
         X509Certificate certificate =  ClientIntegrityValidator.getCertificate();

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/update/ManifestSignerTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/update/ManifestSignerTest.java
@@ -72,7 +72,7 @@ public class ManifestSignerTest {
     }
 
     @Test
-    public void signFile_writesDetachedSignatureThatVerifies() throws Exception {
+    public void signFile_validKey_writesVerifiableDetachedSignature() throws Exception {
         File data = new File(tempDir, "MANIFEST.MF");
         File sig = new File(tempDir, "MANIFEST.MF.sig");
         Files.write(data.toPath(), "lib manifest body".getBytes(StandardCharsets.UTF_8));
@@ -86,7 +86,7 @@ public class ManifestSignerTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void loadPrivateKey_unknownAlias_throws() throws Exception {
+    public void loadPrivateKey_unknownAlias_throwsException() throws Exception {
         ManifestSigner.loadPrivateKey(keystore, STORE_PASS.toCharArray(), "no-such-alias");
     }
 

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/update/ManifestSignerTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/update/ManifestSignerTest.java
@@ -1,3 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 package io.mosip.registration.test.update;
 
 import io.mosip.registration.update.ManifestSigner;

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/update/ManifestSignerTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/update/ManifestSignerTest.java
@@ -1,0 +1,119 @@
+package io.mosip.registration.test.update;
+
+import io.mosip.registration.update.ManifestSigner;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+
+/**
+ * Verifies that {@link ManifestSigner} produces detached signatures that the launcher's
+ * {@code SHA256withRSA}/{@code provider.pem} verification accepts.
+ */
+public class ManifestSignerTest {
+
+    private static final String ALIAS = "CodeSigning";
+    private static final String STORE_PASS = "changeit";
+
+    private static File tempDir;
+    private static File keystore;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("manifest-signer-test").toFile();
+        keystore = new File(tempDir, "keystore.p12");
+        generateKeystore(keystore);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (tempDir != null && tempDir.exists()) {
+            for (File f : tempDir.listFiles()) {
+                Files.deleteIfExists(f.toPath());
+            }
+            Files.deleteIfExists(tempDir.toPath());
+        }
+    }
+
+    @Test
+    public void sign_roundTrip_verifies() throws Exception {
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        byte[] data = "MANIFEST contents".getBytes(StandardCharsets.UTF_8);
+
+        byte[] signature = ManifestSigner.sign(data, keyPair.getPrivate());
+
+        Assert.assertTrue(verify(data, signature, keyPair.getPublic()));
+    }
+
+    @Test
+    public void sign_tamperedData_failsVerification() throws Exception {
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        byte[] signature = ManifestSigner.sign("original".getBytes(StandardCharsets.UTF_8), keyPair.getPrivate());
+
+        Assert.assertFalse(verify("tampered".getBytes(StandardCharsets.UTF_8), signature, keyPair.getPublic()));
+    }
+
+    @Test
+    public void signFile_writesDetachedSignatureThatVerifies() throws Exception {
+        File data = new File(tempDir, "MANIFEST.MF");
+        File sig = new File(tempDir, "MANIFEST.MF.sig");
+        Files.write(data.toPath(), "lib manifest body".getBytes(StandardCharsets.UTF_8));
+
+        PrivateKey privateKey = ManifestSigner.loadPrivateKey(keystore, STORE_PASS.toCharArray(), ALIAS);
+        ManifestSigner.signFile(data, sig, privateKey);
+
+        Assert.assertTrue(sig.exists());
+        Assert.assertTrue(Files.size(sig.toPath()) > 0);
+        Assert.assertTrue(verify(Files.readAllBytes(data.toPath()), Files.readAllBytes(sig.toPath()), publicKeyFromKeystore()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void loadPrivateKey_unknownAlias_throws() throws Exception {
+        ManifestSigner.loadPrivateKey(keystore, STORE_PASS.toCharArray(), "no-such-alias");
+    }
+
+    private static boolean verify(byte[] data, byte[] signature, PublicKey publicKey) throws Exception {
+        Signature verifier = Signature.getInstance("SHA256withRSA");
+        verifier.initVerify(publicKey);
+        verifier.update(data);
+        return verifier.verify(signature);
+    }
+
+    private static PublicKey publicKeyFromKeystore() throws Exception {
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        try (java.io.FileInputStream in = new java.io.FileInputStream(keystore)) {
+            ks.load(in, STORE_PASS.toCharArray());
+        }
+        return ks.getCertificate(ALIAS).getPublicKey();
+    }
+
+    private static void generateKeystore(File target) throws Exception {
+        String keytool = new File(System.getProperty("java.home"), "bin/keytool").getPath();
+        Process process = new ProcessBuilder(
+                keytool,
+                "-genkeypair",
+                "-alias", ALIAS,
+                "-keyalg", "RSA",
+                "-keysize", "2048",
+                "-dname", "CN=Test, OU=Registration, O=MOSIP",
+                "-validity", "365",
+                "-storetype", "PKCS12",
+                "-keystore", target.getPath(),
+                "-storepass", STORE_PASS,
+                "-keypass", STORE_PASS)
+                .redirectErrorStream(true)
+                .start();
+        int exit = process.waitFor();
+        Assert.assertEquals("keytool failed to generate test keystore", 0, exit);
+    }
+}

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/update/ManifestSignerTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/update/ManifestSignerTest.java
@@ -15,6 +15,7 @@ import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
+import java.util.UUID;
 
 /**
  * Verifies that {@link ManifestSigner} produces detached signatures that the launcher's
@@ -23,7 +24,9 @@ import java.security.Signature;
 public class ManifestSignerTest {
 
     private static final String ALIAS = "CodeSigning";
-    private static final String STORE_PASS = "changeit";
+    // Generated per test run so no credential literal is committed. The keystore it protects is a
+    // throwaway PKCS12 created in a temp dir (@BeforeClass) and deleted in @AfterClass.
+    private static final String STORE_PASS = UUID.randomUUID().toString();
 
     private static File tempDir;
     private static File keystore;


### PR DESCRIPTION
Refer Story https://github.com/mosip/registration-client/issues/807
Fixes https://github.com/mosip/registration-client/issues/812

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced the upgrade build flow to generate dual manifest artifacts, including detached `MANIFEST.MF` signatures, packaged `lib` contents, and a bundled JRE archive for deployment.
  * Added a build-time signing utility to produce detached signatures for manifest data.

* **Bug Fixes**
  * Improved manifest creation resilience by warning and skipping missing or non-standard artifacts instead of failing.

* **Tests**
  * Added/expanded tests for manifest generation “list mode,” missing-input skipping, and signature round-trip + tamper verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->