### PR TITLE
T3 (#809) & T4 (#811): Added native migration/rollback executables

### DIFF
--- a/native/.gitattributes
+++ b/native/.gitattributes
@@ -1,0 +1,5 @@
+# Go source is LF by convention (gofmt/goimports emit LF). Pin it so Windows
+# checkouts don't introduce CRLF, which would trip gofmt in golangci-lint.
+*.go   text eol=lf
+go.mod text eol=lf
+go.sum text eol=lf

--- a/native/.gitignore
+++ b/native/.gitignore
@@ -1,0 +1,4 @@
+# build outputs
+*.exe
+# runtime log written by rollback.exe/migration.exe
+*.log

--- a/native/.golangci.yml
+++ b/native/.golangci.yml
@@ -1,0 +1,25 @@
+# Lint config for the native upgrade executables (migration.exe / rollback.exe).
+# Mirrors the mosip/esignet develop-go service config for consistency across the
+# org's Go code; only the goimports local-prefix differs (our module path).
+#
+# Not required to build/test - go vet (in build.ps1) is the essential gate. This
+# adds the stricter golangci-lint pass used in CI. Run locally with:
+#   golangci-lint run    (https://golangci-lint.run)
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - errorlint
+    - gocritic
+    - misspell
+    - revive
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/mosip/registration-client/native

--- a/native/README.md
+++ b/native/README.md
@@ -1,0 +1,79 @@
+# Native migration tooling (Go) — `migration.exe` / `rollback.exe`
+
+Native Windows executables for the Java 11 → 21 JRE migration (the upgrade-revamp
+feature). They perform the JRE swap **outside the JVM**, because the swap
+deletes/replaces the very `jre/` a running JVM would hold open (Windows locks
+in-use files). `_launcher.jar` starts them and exits the JVM first.
+
+**Toolchain: Go (locked in).** GraalVM-Java remains in `../native-java/` only as
+the evaluated alternative behind `design/registration/decision-01-native-toolchain.md`.
+
+| Output | Role | Status |
+|--------|------|--------|
+| `rollback.exe`  | Restore the pre-migration state after a failed/aborted migration | **Logic complete** (`cmd/rollback`, 4 tests) |
+| `migration.exe` | Perform the Java 11 → 21 JRE swap | **Logic complete** (`cmd/migration`, 6 tests; auto-invokes `rollback.exe` on failure) |
+
+## Why Go (this scaffold)
+- Single **static `.exe`, no runtime dependency** (the hard requirement — these run when the JRE is mid-swap/absent).
+- File ops are stdlib (`os`, `path/filepath`); the operator dialog is a one-line `user32!MessageBoxW` syscall — no GUI toolkit.
+- Cross-compiles to Windows from any OS; tiny binary.
+- (Comparison candidate vs GraalVM `native-image`, which keeps the language Java but adds the GraalVM + MSVC toolchain. Same logic either way.)
+
+## Layout
+Two thin `cmd/` entrypoints build the two exes; **both migration and rollback
+logic live together in a single file**, `internal/upgrade/upgrade.go`.
+```
+native/
+  go.mod
+  cmd/
+    rollback/        rollback.exe  - thin main(): dialog/exit/log -> upgrade.Rollback
+      main.go
+    migration/       migration.exe - thin main(): dialog/exit/log + invokeRollback -> upgrade.Migrate
+      main.go
+  internal/
+    upgrade/         Migrate(base) + Rollback(base) - BOTH flows in upgrade.go
+      upgrade.go
+      migrate_test.go / rollback_test.go / helpers_test.go   (6 + 4 tests)
+    appenv/          resolve app root from the exe location (not CWD)
+    fsops/           idempotent move/remove/clean/restore (+ CopyFile, Unzip)
+    jre/             detect JRE feature version from <jre>/release
+    ui/              MessageBoxW (windows) + stdout stub (dev)
+```
+
+## `migration.exe` behaviour (design step 4)
+Idempotent/resumable. Against the app root:
+1. extract `.artifacts/jre21.zip → jre21_temp/` (only if missing — done first so a failed extract never destroys `jre/`)
+2. back up `jre/ → jre11/` (once, only when on JRE 11)
+3. promote `jre21_temp/ → jre/` (delete old `jre/`, rename)
+4. reset `lib/` to just `_launcher.jar` (new jars arrive from `.TEMP/` via `run.bat` on restart)
+5. restore `run.bat` from `.artifacts/`
+6. success dialog — **on any failure, auto-invoke `rollback.exe` and exit non-zero** (design Scenarios 1 & 5)
+
+## `rollback.exe` behaviour (design step 4a)
+Idempotent, safe to re-run. Against the app root:
+1. `jre11/ → jre/` (skip if no backup — never deletes `jre/` without a replacement)
+2. remove `jre21_temp/`
+3. `run.bat_jre11 → run.bat` (skip if no backup)
+4. empty `.TEMP/`, remove `.artifacts/` (re-downloaded on retry — design P8 / N12 / Scenario 5)
+5. completion dialog
+6. **never touches `./MANIFEST.MF`** (preserves the version mismatch for retry) — asserted via a before/after fingerprint
+
+## Build + test (one step)
+```powershell
+./build.ps1            # go vet + go test, then build both .exe into ./dist
+./build.ps1 -TestOnly  # vet + test only
+```
+
+Or by hand:
+```bash
+go vet ./...
+go test ./...          # runs on any OS (ui has a non-windows stub)
+
+# build ON or FOR Windows; -H=windowsgui = no console window
+go build -ldflags "-H=windowsgui" -o dist/rollback.exe  ./cmd/rollback
+go build -ldflags "-H=windowsgui" -o dist/migration.exe ./cmd/migration
+
+# cross-compile from Linux/macOS:
+GOOS=windows GOARCH=amd64 go build -ldflags "-H=windowsgui" -o dist/rollback.exe ./cmd/rollback
+```
+

--- a/native/README.md
+++ b/native/README.md
@@ -5,9 +5,6 @@ feature). They perform the JRE swap **outside the JVM**, because the swap
 deletes/replaces the very `jre/` a running JVM would hold open (Windows locks
 in-use files). `_launcher.jar` starts them and exits the JVM first.
 
-**Toolchain: Go (locked in).** GraalVM-Java remains in `../native-java/` only as
-the evaluated alternative behind `design/registration/decision-01-native-toolchain.md`.
-
 | Output | Role | Status |
 |--------|------|--------|
 | `rollback.exe`  | Restore the pre-migration state after a failed/aborted migration | **Logic complete** (`cmd/rollback`, 4 tests) |

--- a/native/README.md
+++ b/native/README.md
@@ -10,10 +10,10 @@ in-use files). `_launcher.jar` starts them and exits the JVM first.
 | `rollback.exe`  | Restore the pre-migration state after a failed/aborted migration | **Logic complete** (`cmd/rollback`, 4 tests) |
 | `migration.exe` | Perform the Java 11 → 21 JRE swap | **Logic complete** (`cmd/migration`, 6 tests; auto-invokes `rollback.exe` on failure) |
 
-## Why Go (this scaffold)
+## Why Go
 - Single **static `.exe`, no runtime dependency** (the hard requirement — these run when the JRE is mid-swap/absent).
 - File ops are stdlib (`os`, `path/filepath`); the operator dialog is a one-line `user32!MessageBoxW` syscall — no GUI toolkit.
-- Cross-compiles to Windows from any OS; tiny binary.
+- Cross-compiles to Windows from any OS; small, self-contained binary.
 - (Comparison candidate vs GraalVM `native-image`, which keeps the language Java but adds the GraalVM + MSVC toolchain. Same logic either way.)
 
 ## Layout
@@ -34,7 +34,7 @@ native/
     appenv/          resolve app root from the exe location (not CWD)
     fsops/           idempotent move/remove/clean/restore (+ CopyFile, Unzip)
     jre/             detect JRE feature version from <jre>/release
-    ui/              MessageBoxW (windows) + stdout stub (dev)
+    ui/              MessageBoxW (Windows) + stdout stub (dev)
 ```
 
 ## `migration.exe` behaviour (design step 4)
@@ -64,13 +64,14 @@ Idempotent, safe to re-run. Against the app root:
 Or by hand:
 ```bash
 go vet ./...
-go test ./...          # runs on any OS (ui has a non-windows stub)
+go test ./...          # runs on any OS (ui has a non-Windows stub)
 
 # build ON or FOR Windows; -H=windowsgui = no console window
 go build -ldflags "-H=windowsgui" -o dist/rollback.exe  ./cmd/rollback
 go build -ldflags "-H=windowsgui" -o dist/migration.exe ./cmd/migration
 
 # cross-compile from Linux/macOS:
-GOOS=windows GOARCH=amd64 go build -ldflags "-H=windowsgui" -o dist/rollback.exe ./cmd/rollback
+GOOS=windows GOARCH=amd64 go build -ldflags "-H=windowsgui" -o dist/rollback.exe  ./cmd/rollback
+GOOS=windows GOARCH=amd64 go build -ldflags "-H=windowsgui" -o dist/migration.exe ./cmd/migration
 ```
 

--- a/native/build.ps1
+++ b/native/build.ps1
@@ -1,0 +1,50 @@
+# Build + verify the T3/T4 native upgrade executables (migration.exe / rollback.exe).
+#
+#   ./build.ps1            # vet + test, then build both .exe into ./dist
+#   ./build.ps1 -TestOnly  # vet + test only (no .exe produced)
+#
+# Requires the Go toolchain on PATH (https://go.dev/dl/ or: winget install GoLang.Go).
+# The .exe still needs Authenticode signing before release (see README.md).
+[CmdletBinding()]
+param(
+    [switch]$TestOnly
+)
+
+$ErrorActionPreference = 'Stop'
+Set-Location -Path $PSScriptRoot
+
+if (-not (Get-Command go -ErrorAction SilentlyContinue)) {
+    throw "Go toolchain not found on PATH. Install it (winget install GoLang.Go) and re-run."
+}
+Write-Host ("Using {0}" -f (go version))
+
+Write-Host "`n== go vet ==" -ForegroundColor Cyan
+go vet ./...
+if ($LASTEXITCODE -ne 0) { throw "go vet failed" }
+
+Write-Host "`n== go test ==" -ForegroundColor Cyan
+go test ./...
+if ($LASTEXITCODE -ne 0) { throw "go test failed" }
+
+if ($TestOnly) {
+    Write-Host "`nTests passed (TestOnly: no binaries built)." -ForegroundColor Green
+    return
+}
+
+$dist = Join-Path $PSScriptRoot 'dist'
+New-Item -ItemType Directory -Force -Path $dist | Out-Null
+
+# -H=windowsgui => no console window pops up when run.bat / _launcher.jar launches it.
+$ldflags = '-H=windowsgui'
+$env:GOOS = 'windows'
+$env:GOARCH = 'amd64'
+
+foreach ($cmd in @('rollback', 'migration')) {
+    $out = Join-Path $dist "$cmd.exe"
+    Write-Host ("`n== build {0}.exe ==" -f $cmd) -ForegroundColor Cyan
+    go build -ldflags $ldflags -o $out "./cmd/$cmd"
+    if ($LASTEXITCODE -ne 0) { throw "build $cmd failed" }
+    Write-Host ("  -> {0}" -f $out)
+}
+
+Write-Host "`nDone. Sign the binaries in ./dist before release (see README.md)." -ForegroundColor Green

--- a/native/cmd/migration/main.go
+++ b/native/cmd/migration/main.go
@@ -1,4 +1,8 @@
-// Command migration is the T3 (#809) native executable: migration.exe.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Command migration is the native executable: migration.exe.
 //
 // Thin entrypoint over the shared upgrade logic. It performs the Java 11 -> 21
 // JRE swap from outside the JVM (the swap deletes the very jre/ a JVM would hold

--- a/native/cmd/migration/main.go
+++ b/native/cmd/migration/main.go
@@ -70,3 +70,4 @@ func invokeRollback(base string) error {
 	log.Printf("auto-invoking rollback.exe")
 	return exec.Command(rb).Start()
 }
+

--- a/native/cmd/migration/main.go
+++ b/native/cmd/migration/main.go
@@ -50,8 +50,20 @@ func run() int {
 
 	if err := upgrade.Migrate(base); err != nil {
 		log.Printf("migration FAILED: %v", err)
-		// Design step 4 / Scenarios 1 & 5: on failure, auto-invoke rollback.exe,
-		// which restores the previous state and shows its own dialog.
+		// Design step 4a: auto-invoke rollback.exe on failure, EXCEPT once the
+		// JRE swap has already completed (jre/ is a valid Java 21). A late-stage
+		// failure after the swap (lib/ reset or run.bat copy) must NOT roll back
+		// — that would downgrade a good swap; the idempotent migration.exe is
+		// simply re-run on the next launch to retry the failed tail steps.
+		if !upgrade.ShouldRollback(base) {
+			log.Printf("skipping rollback: JRE swap intact, migration is re-runnable")
+			ui.ShowError(dialogTitle,
+				"Migration could not be completed: "+err.Error()+
+					"\n\nThe JRE is already in place and nothing was rolled back. "+
+					"Please restart the application to finish the migration.")
+			return 1
+		}
+		// Scenarios 1 & 5: restore the previous state; rollback.exe shows its own dialog.
 		if rbErr := invokeRollback(base); rbErr != nil {
 			log.Printf("could not launch rollback.exe: %v", rbErr)
 			ui.ShowError(dialogTitle,

--- a/native/cmd/migration/main.go
+++ b/native/cmd/migration/main.go
@@ -1,0 +1,72 @@
+// Command migration is the T3 (#809) native executable: migration.exe.
+//
+// Thin entrypoint over the shared upgrade logic. It performs the Java 11 -> 21
+// JRE swap from outside the JVM (the swap deletes the very jre/ a JVM would hold
+// open). It is launched by _launcher.jar (which then exits the JVM) and is
+// idempotent/resumable. On failure it auto-invokes rollback.exe (T4).
+//
+// The migration + rollback logic both live in ../../internal/upgrade.
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/mosip/registration-client/native/internal/appenv"
+	"github.com/mosip/registration-client/native/internal/fsops"
+	"github.com/mosip/registration-client/native/internal/ui"
+	"github.com/mosip/registration-client/native/internal/upgrade"
+)
+
+const (
+	dialogTitle    = "Registration Client - JRE Migration"
+	successMessage = "JRE migration complete. Please start the application using run.bat."
+)
+
+func main() { os.Exit(run()) }
+
+// run performs the migration and returns the process exit code. Keeping os.Exit
+// in main (not here) lets the deferred log-file close actually run.
+func run() int {
+	base, err := appenv.AppRoot()
+	if err != nil {
+		ui.ShowError(dialogTitle, "Could not determine the application directory: "+err.Error())
+		return 1
+	}
+
+	if f, e := os.OpenFile(filepath.Join(base, "migration.log"),
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644); e == nil {
+		defer func() { _ = f.Close() }()
+		log.SetOutput(f)
+	}
+	log.Printf("migration started, base=%s", base)
+
+	if err := upgrade.Migrate(base); err != nil {
+		log.Printf("migration FAILED: %v", err)
+		// Design step 4 / Scenarios 1 & 5: on failure, auto-invoke rollback.exe,
+		// which restores the previous state and shows its own dialog.
+		if rbErr := invokeRollback(base); rbErr != nil {
+			log.Printf("could not launch rollback.exe: %v", rbErr)
+			ui.ShowError(dialogTitle,
+				"Migration failed: "+err.Error()+"\n\nRollback could not be started: "+rbErr.Error())
+		}
+		return 1
+	}
+
+	log.Printf("migration completed successfully")
+	ui.ShowInfo(dialogTitle, successMessage)
+	return 0
+}
+
+// invokeRollback fire-and-forget launches rollback.exe from the app root.
+func invokeRollback(base string) error {
+	rb := filepath.Join(base, "rollback.exe")
+	if !fsops.Exists(rb) {
+		return fmt.Errorf("rollback.exe not found at %s", rb)
+	}
+	log.Printf("auto-invoking rollback.exe")
+	return exec.Command(rb).Start()
+}

--- a/native/cmd/rollback/main.go
+++ b/native/cmd/rollback/main.go
@@ -55,3 +55,4 @@ func run() int {
 	ui.ShowInfo(dialogTitle, successMessage)
 	return 0
 }
+

--- a/native/cmd/rollback/main.go
+++ b/native/cmd/rollback/main.go
@@ -1,4 +1,8 @@
-// Command rollback is the T4 (#811) native executable: rollback.exe.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Command rollback is the native executable: rollback.exe.
 //
 // Thin entrypoint over the shared upgrade logic. It restores the Registration
 // Client to its pre-migration state after a failed or aborted Java 11 -> 21

--- a/native/cmd/rollback/main.go
+++ b/native/cmd/rollback/main.go
@@ -1,0 +1,57 @@
+// Command rollback is the T4 (#811) native executable: rollback.exe.
+//
+// Thin entrypoint over the shared upgrade logic. It restores the Registration
+// Client to its pre-migration state after a failed or aborted Java 11 -> 21
+// migration. It is invoked by migration.exe on failure, by _launcher.jar on an
+// inconsistent-JRE startup, or manually by an operator. It is fully idempotent
+// and never touches ./MANIFEST.MF, so the version mismatch is preserved and the
+// upgrade can be retried later.
+//
+// The migration + rollback logic both live in ../../internal/upgrade.
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/mosip/registration-client/native/internal/appenv"
+	"github.com/mosip/registration-client/native/internal/ui"
+	"github.com/mosip/registration-client/native/internal/upgrade"
+)
+
+const (
+	dialogTitle    = "Registration Client - Rollback"
+	successMessage = "Rollback complete. Application restored to previous state. Please start using run.bat."
+)
+
+func main() { os.Exit(run()) }
+
+// run performs the rollback and returns the process exit code. Keeping os.Exit
+// in main (not here) lets the deferred log-file close actually run.
+func run() int {
+	base, err := appenv.AppRoot()
+	if err != nil {
+		ui.ShowError(dialogTitle, "Could not determine the application directory: "+err.Error())
+		return 1
+	}
+
+	// Best-effort file log in the app root (the windowsgui build has no console).
+	if f, e := os.OpenFile(filepath.Join(base, "rollback.log"),
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644); e == nil {
+		defer func() { _ = f.Close() }()
+		log.SetOutput(f)
+	}
+	log.Printf("rollback started, base=%s", base)
+
+	if err := upgrade.Rollback(base); err != nil {
+		log.Printf("rollback FAILED: %v", err)
+		ui.ShowError(dialogTitle,
+			"Rollback failed: "+err.Error()+"\n\nYou can retry by running rollback.exe again.")
+		return 1
+	}
+
+	log.Printf("rollback completed successfully")
+	ui.ShowInfo(dialogTitle, successMessage)
+	return 0
+}

--- a/native/go.mod
+++ b/native/go.mod
@@ -1,0 +1,3 @@
+module github.com/mosip/registration-client/native
+
+go 1.21

--- a/native/internal/appenv/appenv.go
+++ b/native/internal/appenv/appenv.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 // Package appenv resolves the Registration Client application root directory.
 //
 // The migration/rollback executables live in the app root (next to run.bat,

--- a/native/internal/appenv/appenv.go
+++ b/native/internal/appenv/appenv.go
@@ -1,0 +1,25 @@
+// Package appenv resolves the Registration Client application root directory.
+//
+// The migration/rollback executables live in the app root (next to run.bat,
+// jre/, lib/, ./MANIFEST.MF). They may be launched by run.bat, by migration.exe,
+// or manually by an operator, so the working directory is not reliable. We resolve
+// the app root from the executable's own location instead.
+package appenv
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// AppRoot returns the directory containing the running executable, with symlinks
+// resolved. This is the Registration Client application root.
+func AppRoot() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	return filepath.Dir(exe), nil
+}

--- a/native/internal/fsops/archive.go
+++ b/native/internal/fsops/archive.go
@@ -1,0 +1,82 @@
+package fsops
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CopyFile copies src to dst, creating dst's parent directory if needed.
+func CopyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}
+
+// Unzip extracts the archive at zipPath into destDir, guarding against zip-slip
+// (entries that would escape destDir). The jre21.zip input is a signed artifact,
+// but the guard is cheap defence-in-depth.
+func Unzip(zipPath, destDir string) error {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = r.Close() }()
+
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return err
+	}
+	cleanDest := filepath.Clean(destDir)
+
+	for _, f := range r.File {
+		target := filepath.Clean(filepath.Join(destDir, f.Name))
+		if target != cleanDest && !strings.HasPrefix(target, cleanDest+string(os.PathSeparator)) {
+			return fmt.Errorf("illegal path in zip: %s", f.Name)
+		}
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if err := extractZipFile(f, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func extractZipFile(f *zip.File, target string) error {
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rc.Close() }()
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+	_, err = io.Copy(out, rc)
+	return err
+}

--- a/native/internal/fsops/archive.go
+++ b/native/internal/fsops/archive.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package fsops
 
 import (

--- a/native/internal/fsops/fsops.go
+++ b/native/internal/fsops/fsops.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 // Package fsops provides the small set of idempotent filesystem operations the
 // migration/rollback executables need. Each operation is safe to run repeatedly
 // (e.g. after an operator force-kill) and treats "source already absent" as a

--- a/native/internal/fsops/fsops.go
+++ b/native/internal/fsops/fsops.go
@@ -1,0 +1,66 @@
+// Package fsops provides the small set of idempotent filesystem operations the
+// migration/rollback executables need. Each operation is safe to run repeatedly
+// (e.g. after an operator force-kill) and treats "source already absent" as a
+// no-op rather than an error.
+package fsops
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Exists reports whether path exists (file or directory).
+func Exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// MoveDir renames src to dst. On Windows os.Rename fails if dst exists, so any
+// existing dst (e.g. a partially-populated jre/ from a failed migration) is
+// removed first. src and dst are expected to be on the same volume (both under
+// the app root), so the rename is atomic.
+func MoveDir(src, dst string) error {
+	if Exists(dst) {
+		if err := os.RemoveAll(dst); err != nil {
+			return err
+		}
+	}
+	return os.Rename(src, dst)
+}
+
+// RemoveAll deletes path and any children. Absent path is not an error.
+func RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}
+
+// CleanContents removes everything inside dir but keeps dir itself. A missing
+// dir is not an error.
+func CleanContents(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for _, e := range entries {
+		if err := os.RemoveAll(filepath.Join(dir, e.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RestoreFile replaces target with backup (target removed, backup renamed to
+// target). If backup is absent it is a no-op.
+func RestoreFile(backup, target string) error {
+	if !Exists(backup) {
+		return nil
+	}
+	if Exists(target) {
+		if err := os.Remove(target); err != nil {
+			return err
+		}
+	}
+	return os.Rename(backup, target)
+}

--- a/native/internal/jre/jre.go
+++ b/native/internal/jre/jre.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 // Package jre detects the feature version of a JRE from its release file, used
 // by migration.exe to decide whether to back up the Java 11 JRE.
 package jre

--- a/native/internal/jre/jre.go
+++ b/native/internal/jre/jre.go
@@ -25,7 +25,10 @@ func DetectMajor(jreDir string) int {
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		line := scanner.Text()
+		// Tolerate a UTF-8 BOM on the first line: some editors/scripts re-save
+		// the release file with a leading U+FEFF, which would otherwise defeat
+		// the HasPrefix check and silently degrade detection to 0.
+		line := strings.TrimPrefix(scanner.Text(), "\uFEFF")
 		if strings.HasPrefix(line, "JAVA_VERSION=") {
 			value := strings.Trim(strings.TrimPrefix(line, "JAVA_VERSION="), "\"")
 			return parseMajor(value)

--- a/native/internal/jre/jre.go
+++ b/native/internal/jre/jre.go
@@ -1,0 +1,54 @@
+// Package jre detects the feature version of a JRE from its release file, used
+// by migration.exe to decide whether to back up the Java 11 JRE.
+package jre
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// DetectMajor reads <jreDir>/release and returns the Java feature version
+// (e.g. 11, 21), or 0 if it cannot be determined.
+func DetectMajor(jreDir string) int {
+	f, err := os.Open(filepath.Join(jreDir, "release"))
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "JAVA_VERSION=") {
+			value := strings.Trim(strings.TrimPrefix(line, "JAVA_VERSION="), "\"")
+			return parseMajor(value)
+		}
+	}
+	return 0
+}
+
+// parseMajor maps a java.version string to its feature number:
+// "11.0.20" -> 11, "21" -> 21, "1.8.0_392" -> 8.
+func parseMajor(version string) int {
+	version = strings.TrimSpace(version)
+	if strings.HasPrefix(version, "1.") {
+		parts := strings.Split(version, ".")
+		if len(parts) >= 2 {
+			if n, err := strconv.Atoi(parts[1]); err == nil {
+				return n
+			}
+		}
+		return 0
+	}
+	if idx := strings.IndexAny(version, ".+_-"); idx > 0 {
+		version = version[:idx]
+	}
+	n, err := strconv.Atoi(version)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/native/internal/jre/jre_test.go
+++ b/native/internal/jre/jre_test.go
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package jre
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectMajor(t *testing.T) {
+	cases := []struct {
+		name    string
+		release string
+		want    int
+	}{
+		{"java11", `JAVA_VERSION="11.0.20"`, 11},
+		{"java21", `JAVA_VERSION="21.0.1"`, 21},
+		{"legacy8", `JAVA_VERSION="1.8.0_392"`, 8},
+		// A UTF-8 BOM on the first line must not defeat detection (regression:
+		// release files re-saved by PowerShell/editors gain a leading U+FEFF,
+		// which previously degraded detection to 0).
+		{"bom", "\uFEFF" + `JAVA_VERSION="11.0.20"`, 11},
+		{"noVersionLine", "IMPLEMENTOR=\"Eclipse\"\n", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "release"), []byte(tc.release+"\n"), 0o644); err != nil {
+				t.Fatalf("write release: %v", err)
+			}
+			if got := DetectMajor(dir); got != tc.want {
+				t.Errorf("DetectMajor = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectMajor_MissingReleaseFile(t *testing.T) {
+	if got := DetectMajor(t.TempDir()); got != 0 {
+		t.Errorf("DetectMajor with no release file = %d, want 0", got)
+	}
+}

--- a/native/internal/ui/dialog_other.go
+++ b/native/internal/ui/dialog_other.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+// Non-Windows stub so the module builds and tests on developer machines
+// (Linux/macOS). The shipped artifact is always the windows build.
+package ui
+
+import "fmt"
+
+// ShowInfo prints the dialog to stdout on non-Windows platforms.
+func ShowInfo(title, message string) { fmt.Printf("[INFO]  %s :: %s\n", title, message) }
+
+// ShowError prints the dialog to stderr-style stdout on non-Windows platforms.
+func ShowError(title, message string) { fmt.Printf("[ERROR] %s :: %s\n", title, message) }

--- a/native/internal/ui/dialog_other.go
+++ b/native/internal/ui/dialog_other.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //go:build !windows
 
 // Non-Windows stub so the module builds and tests on developer machines

--- a/native/internal/ui/dialog_windows.go
+++ b/native/internal/ui/dialog_windows.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //go:build windows
 
 // Package ui shows the operator dialogs required by the migration/rollback flow.

--- a/native/internal/ui/dialog_windows.go
+++ b/native/internal/ui/dialog_windows.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+// Package ui shows the operator dialogs required by the migration/rollback flow.
+// On Windows it calls user32!MessageBoxW directly via syscall, so the binary has
+// no GUI-toolkit dependency and can be built with the windowsgui subsystem.
+package ui
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	user32          = syscall.NewLazyDLL("user32.dll")
+	procMessageBoxW = user32.NewProc("MessageBoxW")
+)
+
+const (
+	mbOK              = 0x00000000
+	mbIconError       = 0x00000010
+	mbIconInformation = 0x00000040
+)
+
+// ShowInfo displays an informational, OK-only modal dialog.
+func ShowInfo(title, message string) { messageBox(title, message, mbIconInformation) }
+
+// ShowError displays an error, OK-only modal dialog.
+func ShowError(title, message string) { messageBox(title, message, mbIconError) }
+
+func messageBox(title, message string, icon uintptr) {
+	titlePtr, _ := syscall.UTF16PtrFromString(title)
+	msgPtr, _ := syscall.UTF16PtrFromString(message)
+	// MessageBoxW always sets a non-nil syscall error ("operation completed
+	// successfully"); the return values are not meaningful for an OK-only dialog.
+	_, _, _ = procMessageBoxW.Call(
+		0,
+		uintptr(unsafe.Pointer(msgPtr)),
+		uintptr(unsafe.Pointer(titlePtr)),
+		mbOK|icon,
+	)
+}

--- a/native/internal/upgrade/helpers_test.go
+++ b/native/internal/upgrade/helpers_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package upgrade
 
 import (

--- a/native/internal/upgrade/helpers_test.go
+++ b/native/internal/upgrade/helpers_test.go
@@ -1,0 +1,84 @@
+package upgrade
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// mustWrite writes content to path, creating parent directories as needed.
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// mustRead returns the contents of path or fails the test.
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+// mustDirWith creates dir and writes a single file into it.
+func mustDirWith(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(dir, name), content)
+}
+
+// writeJre stages a fake JRE: a release file (for DetectMajor) and a marker.
+func writeJre(t *testing.T, dir, version, marker string) {
+	t.Helper()
+	mustWrite(t, filepath.Join(dir, "release"), "JAVA_VERSION=\""+version+"\"\n")
+	mustWrite(t, filepath.Join(dir, "marker.txt"), marker)
+}
+
+func assertContent(t *testing.T, path, want string) {
+	t.Helper()
+	if got := mustRead(t, path); got != want {
+		t.Errorf("%s = %q, want %q", path, got, want)
+	}
+}
+
+func assertAbsent(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected %s absent, stat err=%v", path, err)
+	}
+}
+
+func makeZip(t *testing.T, zipPath string, files map[string]string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(zipPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	zw := zip.NewWriter(f)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/native/internal/upgrade/migrate_test.go
+++ b/native/internal/upgrade/migrate_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package upgrade
 
 import (

--- a/native/internal/upgrade/migrate_test.go
+++ b/native/internal/upgrade/migrate_test.go
@@ -1,0 +1,133 @@
+package upgrade
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// P3-style: _launcher.jar already extracted jre21_temp/; migration promotes it.
+func TestMigrate_PromotesExtractedTemp(t *testing.T) {
+	base := t.TempDir()
+	writeJre(t, filepath.Join(base, "jre"), "11.0.20", "old11")
+	writeJre(t, filepath.Join(base, "jre21_temp"), "21.0.1", "new21")
+	artifacts := filepath.Join(base, ".artifacts")
+	mustWrite(t, filepath.Join(artifacts, "_launcher.jar"), "launcher")
+	mustWrite(t, filepath.Join(artifacts, "run.bat"), "jre21 runbat")
+	mustWrite(t, filepath.Join(base, "lib", "old.jar"), "old")
+
+	if err := Migrate(base); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	assertContent(t, filepath.Join(base, "jre", "marker.txt"), "new21")   // promoted
+	assertAbsent(t, filepath.Join(base, "jre21_temp"))                    // consumed
+	assertContent(t, filepath.Join(base, "jre11", "marker.txt"), "old11") // backed up
+	assertAbsent(t, filepath.Join(base, "lib", "old.jar"))                // lib cleared
+	assertContent(t, filepath.Join(base, "lib", "_launcher.jar"), "launcher")
+	assertContent(t, filepath.Join(base, "run.bat"), "jre21 runbat")
+}
+
+// Fallback path: no jre21_temp/ -> migration extracts jre21.zip itself.
+func TestMigrate_ExtractsWhenNoTemp(t *testing.T) {
+	base := t.TempDir()
+	writeJre(t, filepath.Join(base, "jre"), "11.0.20", "old11")
+	artifacts := filepath.Join(base, ".artifacts")
+	makeZip(t, filepath.Join(artifacts, "jre21.zip"), map[string]string{
+		"release":    "JAVA_VERSION=\"21.0.1\"\n",
+		"marker.txt": "new21",
+	})
+	mustWrite(t, filepath.Join(artifacts, "_launcher.jar"), "launcher")
+	mustWrite(t, filepath.Join(artifacts, "run.bat"), "jre21 runbat")
+
+	if err := Migrate(base); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	assertContent(t, filepath.Join(base, "jre", "marker.txt"), "new21")
+	assertContent(t, filepath.Join(base, "jre11", "marker.txt"), "old11")
+	assertAbsent(t, filepath.Join(base, "jre21_temp"))
+}
+
+// A previous run was hard-killed mid-unzip, leaving a partial jre21_temp.partial/
+// (and no jre21_temp/, since the finalize rename never happened). The re-run must
+// discard the stale .partial, re-extract cleanly, and never promote the garbage.
+func TestMigrate_StalePartialExtract_DiscardedAndReextracted(t *testing.T) {
+	base := t.TempDir()
+	writeJre(t, filepath.Join(base, "jre"), "11.0.20", "old11")
+	// Leftover from an interrupted extraction: a partial dir with garbage and no
+	// release file. It must not survive or be promoted.
+	mustWrite(t, filepath.Join(base, "jre21_temp.partial", "garbage.txt"), "half-written")
+	artifacts := filepath.Join(base, ".artifacts")
+	makeZip(t, filepath.Join(artifacts, "jre21.zip"), map[string]string{
+		"release":    "JAVA_VERSION=\"21.0.1\"\n",
+		"marker.txt": "new21",
+	})
+	mustWrite(t, filepath.Join(artifacts, "_launcher.jar"), "launcher")
+	mustWrite(t, filepath.Join(artifacts, "run.bat"), "jre21 runbat")
+
+	if err := Migrate(base); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	assertContent(t, filepath.Join(base, "jre", "marker.txt"), "new21") // clean extract promoted
+	assertAbsent(t, filepath.Join(base, "jre", "garbage.txt"))          // stale partial not promoted
+	assertAbsent(t, filepath.Join(base, "jre21_temp"))                  // consumed
+	assertAbsent(t, filepath.Join(base, "jre21_temp.partial"))          // discarded
+	assertContent(t, filepath.Join(base, "jre11", "marker.txt"), "old11")
+}
+
+func TestMigrate_Idempotent(t *testing.T) {
+	base := t.TempDir()
+	writeJre(t, filepath.Join(base, "jre"), "11.0.20", "old11")
+	writeJre(t, filepath.Join(base, "jre21_temp"), "21.0.1", "new21")
+	artifacts := filepath.Join(base, ".artifacts")
+	mustWrite(t, filepath.Join(artifacts, "_launcher.jar"), "launcher")
+	mustWrite(t, filepath.Join(artifacts, "run.bat"), "jre21 runbat")
+	mustWrite(t, filepath.Join(base, "lib", "old.jar"), "old")
+
+	if err := Migrate(base); err != nil {
+		t.Fatalf("first Migrate: %v", err)
+	}
+	if err := Migrate(base); err != nil {
+		t.Fatalf("second Migrate (idempotency): %v", err)
+	}
+	assertContent(t, filepath.Join(base, "jre", "marker.txt"), "new21")
+	assertContent(t, filepath.Join(base, "jre11", "marker.txt"), "old11")
+}
+
+// N5/N9-style failure: jre21.zip missing and no jre21_temp -> Migrate errors
+// (migration.exe would then invoke rollback.exe). Extract-first means jre/ is
+// left intact.
+func TestMigrate_MissingJre21_FailsWithoutDestroyingJre(t *testing.T) {
+	base := t.TempDir()
+	writeJre(t, filepath.Join(base, "jre"), "11.0.20", "old11")
+	mustWrite(t, filepath.Join(base, ".artifacts", "_launcher.jar"), "launcher")
+	mustWrite(t, filepath.Join(base, ".artifacts", "run.bat"), "jre21 runbat")
+
+	if err := Migrate(base); err == nil {
+		t.Fatal("expected error when jre21.zip is missing")
+	}
+	assertContent(t, filepath.Join(base, "jre", "marker.txt"), "old11") // untouched
+	assertAbsent(t, filepath.Join(base, "jre11"))
+}
+
+// Safety: jre/ has no readable release file (DetectMajor -> 0). The old JRE
+// must still be backed up to jre11/ before promotion, never deleted without a
+// rollback target.
+func TestMigrate_UndetectableJre_StillBacksUp(t *testing.T) {
+	base := t.TempDir()
+	// jre/ with a marker but NO release file -> major detected as 0.
+	mustWrite(t, filepath.Join(base, "jre", "marker.txt"), "old11")
+	writeJre(t, filepath.Join(base, "jre21_temp"), "21.0.1", "new21")
+	artifacts := filepath.Join(base, ".artifacts")
+	mustWrite(t, filepath.Join(artifacts, "_launcher.jar"), "launcher")
+	mustWrite(t, filepath.Join(artifacts, "run.bat"), "jre21 runbat")
+
+	if err := Migrate(base); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	assertContent(t, filepath.Join(base, "jre11", "marker.txt"), "old11") // backed up, not lost
+	assertContent(t, filepath.Join(base, "jre", "marker.txt"), "new21")   // promoted
+	assertAbsent(t, filepath.Join(base, "jre21_temp"))
+}

--- a/native/internal/upgrade/rollback_test.go
+++ b/native/internal/upgrade/rollback_test.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package upgrade
 
 import (

--- a/native/internal/upgrade/rollback_test.go
+++ b/native/internal/upgrade/rollback_test.go
@@ -1,0 +1,119 @@
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// stageAppRoot builds a fake app root in a temp dir representing a machine that
+// has migrated (or partially migrated) and now needs rolling back:
+//   - jre11/        : the Java 11 backup (marker "jre11")
+//   - jre/          : the partially-populated new JRE (marker "partial")
+//   - jre21_temp/   : leftover extraction dir
+//   - run.bat       : the (Java 21) run.bat
+//   - run.bat_jre11 : the Java 11 run.bat backup
+//   - .TEMP/        : staged files
+//   - .artifacts/   : downloaded upgrade artifacts (must be removed)
+//   - MANIFEST.MF   : must be untouched
+func stageAppRoot(t *testing.T) string {
+	t.Helper()
+	base := t.TempDir()
+	mustDirWith(t, filepath.Join(base, "jre11"), "marker.txt", "jre11")
+	mustDirWith(t, filepath.Join(base, "jre"), "marker.txt", "partial")
+	mustDirWith(t, filepath.Join(base, "jre21_temp"), "x.txt", "tmp")
+	mustWrite(t, filepath.Join(base, "run.bat"), "jre21 runbat")
+	mustWrite(t, filepath.Join(base, "run.bat_jre11"), "jre11 runbat")
+	mustDirWith(t, filepath.Join(base, ".TEMP"), "patch.jar", "data")
+	mustDirWith(t, filepath.Join(base, ".artifacts"), "jre21.zip", "zipdata")
+	mustWrite(t, filepath.Join(base, "MANIFEST.MF"), "Manifest-Version: 1.0\n")
+	return base
+}
+
+func TestRollback_RestoresPreMigrationState(t *testing.T) {
+	base := stageAppRoot(t)
+	manifestBefore := mustRead(t, filepath.Join(base, "MANIFEST.MF"))
+
+	if err := Rollback(base); err != nil {
+		t.Fatalf("Rollback returned error: %v", err)
+	}
+
+	// jre/ restored from jre11/ (marker == "jre11"); jre11/ consumed.
+	if got := mustRead(t, filepath.Join(base, "jre", "marker.txt")); got != "jre11" {
+		t.Errorf("jre/ not restored from jre11/: marker=%q", got)
+	}
+	assertAbsent(t, filepath.Join(base, "jre11"))
+	// jre21_temp/ removed.
+	assertAbsent(t, filepath.Join(base, "jre21_temp"))
+	// run.bat restored from backup; backup consumed.
+	if got := mustRead(t, filepath.Join(base, "run.bat")); got != "jre11 runbat" {
+		t.Errorf("run.bat not restored: %q", got)
+	}
+	assertAbsent(t, filepath.Join(base, "run.bat_jre11"))
+	// .TEMP/ emptied but kept.
+	if entries, _ := os.ReadDir(filepath.Join(base, ".TEMP")); len(entries) != 0 {
+		t.Errorf(".TEMP/ not emptied: %d entries", len(entries))
+	}
+	// .artifacts/ removed (P8 / Scenario 5).
+	assertAbsent(t, filepath.Join(base, ".artifacts"))
+	// MANIFEST.MF untouched.
+	if got := mustRead(t, filepath.Join(base, "MANIFEST.MF")); got != manifestBefore {
+		t.Errorf("MANIFEST.MF changed: %q", got)
+	}
+}
+
+func TestRollback_Idempotent(t *testing.T) {
+	base := stageAppRoot(t)
+	if err := Rollback(base); err != nil {
+		t.Fatalf("first Rollback: %v", err)
+	}
+	// Second run must be a clean no-op success (backups already consumed).
+	if err := Rollback(base); err != nil {
+		t.Fatalf("second Rollback (idempotency) returned error: %v", err)
+	}
+	if got := mustRead(t, filepath.Join(base, "jre", "marker.txt")); got != "jre11" {
+		t.Errorf("jre/ corrupted by second run: marker=%q", got)
+	}
+}
+
+// N12: rollback invoked when jre11/ backup does not exist -> skip JRE restore,
+// still clean the rest, succeed.
+func TestRollback_NoJreBackup_SkipsRestore(t *testing.T) {
+	base := stageAppRoot(t)
+	if err := os.RemoveAll(filepath.Join(base, "jre11")); err != nil {
+		t.Fatal(err)
+	}
+	jreBefore := mustRead(t, filepath.Join(base, "jre", "marker.txt")) // "partial"
+
+	if err := Rollback(base); err != nil {
+		t.Fatalf("Rollback returned error: %v", err)
+	}
+	// jre/ left as-is (no backup to restore from - must NOT be deleted).
+	if got := mustRead(t, filepath.Join(base, "jre", "marker.txt")); got != jreBefore {
+		t.Errorf("jre/ altered without a backup: %q", got)
+	}
+	// Other cleanups still ran (N12: clean .TEMP/ and .artifacts/ even with no backup).
+	assertAbsent(t, filepath.Join(base, "jre21_temp"))
+	if entries, _ := os.ReadDir(filepath.Join(base, ".TEMP")); len(entries) != 0 {
+		t.Errorf(".TEMP/ not emptied")
+	}
+	assertAbsent(t, filepath.Join(base, ".artifacts"))
+}
+
+// Scenario 1: migration failed after deleting jre/ but before promoting the new
+// one. jre/ is absent, jre11/ backup present -> rollback restores it.
+func TestRollback_JreDeleted_RestoresFromBackup(t *testing.T) {
+	base := stageAppRoot(t)
+	if err := os.RemoveAll(filepath.Join(base, "jre")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Rollback(base); err != nil {
+		t.Fatalf("Rollback returned error: %v", err)
+	}
+
+	if got := mustRead(t, filepath.Join(base, "jre", "marker.txt")); got != "jre11" {
+		t.Errorf("jre/ not restored from jre11/: marker=%q", got)
+	}
+	assertAbsent(t, filepath.Join(base, "jre11"))
+}

--- a/native/internal/upgrade/rollback_trigger_test.go
+++ b/native/internal/upgrade/rollback_trigger_test.go
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package upgrade
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// The reviewer's scenario: the JRE swap fully succeeded (jre/ is a complete
+// Java 21, jre11/ backup present) but a late Migrate step (lib/ reset, run.bat
+// copy) failed. ShouldRollback must be false so we do NOT downgrade a good
+// Java 21 swap back to Java 11 — the idempotent migration is simply re-run.
+func TestShouldRollback_Jre21SwapDone_DoesNotRollBack(t *testing.T) {
+	base := t.TempDir()
+	writeJre(t, filepath.Join(base, "jre"), "21.0.1", "new21")
+	writeJre(t, filepath.Join(base, "jre11"), "11.0.20", "old11")
+
+	if ShouldRollback(base) {
+		t.Fatal("ShouldRollback = true; a complete Java 21 jre/ must NOT be rolled back")
+	}
+}
+
+// jre11/ backup exists and jre/ is missing (promote failed after backup) ->
+// design trigger row 1 holds: roll back.
+func TestShouldRollback_JreMissingWithBackup_RollsBack(t *testing.T) {
+	base := t.TempDir()
+	writeJre(t, filepath.Join(base, "jre11"), "11.0.20", "old11")
+	// no jre/ at all
+
+	if !ShouldRollback(base) {
+		t.Fatal("ShouldRollback = false; a missing jre/ with a backup must roll back")
+	}
+}
+
+// jre11/ backup exists and jre/ is partially populated (no readable release ->
+// DetectMajor 0) -> roll back.
+func TestShouldRollback_JrePartial_RollsBack(t *testing.T) {
+	base := t.TempDir()
+	writeJre(t, filepath.Join(base, "jre11"), "11.0.20", "old11")
+	mustWrite(t, filepath.Join(base, "jre", "half.txt"), "partial") // no release file
+
+	if !ShouldRollback(base) {
+		t.Fatal("ShouldRollback = false; a partially-populated jre/ with a backup must roll back")
+	}
+}
+
+// Early failure: extract failed before any backup, so jre/ is still the
+// untouched Java 11 and there is no jre11/. The swap has NOT completed, so
+// rollback is still invoked — it is a no-op on jre/ (no backup) and performs the
+// harmless cleanup the design expects (run.bat_jre11 restore, .artifacts/).
+func TestShouldRollback_StillJava11NoBackup_RollsBack(t *testing.T) {
+	base := t.TempDir()
+	writeJre(t, filepath.Join(base, "jre"), "11.0.20", "old11")
+
+	if !ShouldRollback(base) {
+		t.Fatal("ShouldRollback = false; an incomplete swap (jre/ still Java 11) must roll back")
+	}
+}
+
+// A completed Java 21 swap must never be rolled back even if the jre11/ backup
+// was already cleaned up — do not undo real progress.
+func TestShouldRollback_Jre21NoBackup_DoesNotRollBack(t *testing.T) {
+	base := t.TempDir()
+	writeJre(t, filepath.Join(base, "jre"), "21.0.1", "new21")
+
+	if ShouldRollback(base) {
+		t.Fatal("ShouldRollback = true; a completed Java 21 swap must NOT be rolled back")
+	}
+}

--- a/native/internal/upgrade/upgrade.go
+++ b/native/internal/upgrade/upgrade.go
@@ -1,0 +1,198 @@
+// Package upgrade holds the shared logic for BOTH native upgrade executables in
+// a single file: the Java 11 -> 21 migration (T3 #809, built as migration.exe)
+// and its inverse rollback (T4 #811, built as rollback.exe). Keeping the swap
+// and its undo side by side makes them easy to read and keep in sync; the two
+// cmd/ entrypoints are thin wrappers that call Migrate / Rollback.
+//
+// Both flows run outside the JVM (the swap deletes the very jre/ a JVM would
+// hold open) and are idempotent/resumable.
+package upgrade
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/mosip/registration-client/native/internal/fsops"
+	"github.com/mosip/registration-client/native/internal/jre"
+)
+
+// Migrate performs the idempotent Java 11 -> 21 JRE migration against the app
+// root (design registration-upgrade.md step 4 / issue #809).
+//
+// Steps:
+//  1. extract .artifacts/jre21.zip -> jre21_temp/ (partial-safe; only if missing)
+//  2. back up jre/ -> jre11/ (once, unless already on 21)
+//  3. promote jre21_temp/ -> jre/ (remove old jre/, rename)
+//  4. reset lib/ to just _launcher.jar
+//  5. restore run.bat from .artifacts/
+func Migrate(base string) error {
+	jrePath := filepath.Join(base, "jre")
+	jre11 := filepath.Join(base, "jre11")
+	jre21Temp := filepath.Join(base, "jre21_temp")
+	jre21Zip := filepath.Join(base, ".artifacts", "jre21.zip")
+	lib := filepath.Join(base, "lib")
+	launcherSrc := filepath.Join(base, ".artifacts", "_launcher.jar")
+	launcherDst := filepath.Join(lib, "_launcher.jar")
+	runBatSrc := filepath.Join(base, ".artifacts", "run.bat")
+	runBatDst := filepath.Join(base, "run.bat")
+
+	major := jre.DetectMajor(jrePath)
+	log.Printf("current jre major=%d", major)
+
+	// Extract the new JRE FIRST, before touching jre/, so a failed extraction
+	// never leaves the machine without a JRE. (Normally _launcher.jar already
+	// extracted jre21_temp/ in step 3; this is the resume/fallback path.)
+	//
+	// Extract into a .partial sibling and only rename to jre21_temp/ on success.
+	// jre21_temp/ existence therefore means a *complete* extraction: a hard
+	// kill or power-loss mid-unzip leaves only jre21_temp.partial/ (discarded
+	// and re-extracted on the next run) instead of a half-populated jre21_temp/
+	// that the promote step would mistake for a finished JRE.
+	if !fsops.Exists(jre21Temp) && major != 21 {
+		log.Printf("extracting jre21.zip -> jre21_temp/")
+		partial := jre21Temp + ".partial"
+		if err := fsops.RemoveAll(partial); err != nil {
+			return fmt.Errorf("clear stale jre21_temp.partial/: %w", err)
+		}
+		if err := fsops.Unzip(jre21Zip, partial); err != nil {
+			return fmt.Errorf("extract jre21.zip: %w", err)
+		}
+		if err := os.Rename(partial, jre21Temp); err != nil {
+			return fmt.Errorf("finalize jre21_temp/: %w", err)
+		}
+	}
+
+	// Back up the old JRE once (rename jre/ -> jre11/) before it is replaced.
+	// Guard on "not already on 21" rather than "== 11" so that an undetectable
+	// release (major 0) is still backed up instead of being deleted at promote
+	// with no jre11/ to roll back to; and so a 21 JRE is never mislabelled as
+	// the jre11 backup. Skipped once jre11/ exists (idempotent).
+	if major != 21 && fsops.Exists(jrePath) && !fsops.Exists(jre11) {
+		log.Printf("backing up jre/ -> jre11/ (detected major=%d)", major)
+		if err := os.Rename(jrePath, jre11); err != nil {
+			return fmt.Errorf("back up jre/: %w", err)
+		}
+	}
+
+	// Promote the new JRE into jre/. MoveDir removes any existing jre/ (e.g. a
+	// partially-populated one from a prior failed attempt) before the rename.
+	if fsops.Exists(jre21Temp) {
+		log.Printf("promoting jre21_temp/ -> jre/")
+		if err := fsops.MoveDir(jre21Temp, jrePath); err != nil {
+			return fmt.Errorf("promote jre21_temp/: %w", err)
+		}
+	}
+
+	// lib/ must contain only _launcher.jar after migration; the new jars arrive
+	// from .TEMP/ via run.bat on the next restart.
+	log.Printf("resetting lib/ to _launcher.jar")
+	if err := fsops.CleanContents(lib); err != nil {
+		return fmt.Errorf("clean lib/: %w", err)
+	}
+	if err := fsops.CopyFile(launcherSrc, launcherDst); err != nil {
+		return fmt.Errorf("copy _launcher.jar: %w", err)
+	}
+
+	// Restore the Java 21 run.bat into the app root.
+	if err := fsops.CopyFile(runBatSrc, runBatDst); err != nil {
+		return fmt.Errorf("copy run.bat: %w", err)
+	}
+	return nil
+}
+
+// Rollback restores the Registration Client to its pre-migration state after a
+// failed or aborted migration (design registration-upgrade.md step 4a / issue
+// #811). It is fully idempotent (safe to run multiple times) and never touches
+// ./MANIFEST.MF, so the version mismatch is preserved and the upgrade can be
+// retried later.
+//
+// Steps:
+//  1. restore jre11/ -> jre/ (skip if no backup)
+//  2. remove jre21_temp/
+//  3. restore run.bat_jre11 -> run.bat (skip if no backup)
+//  4. empty .TEMP/, remove .artifacts/
+//  5. invariant: ./MANIFEST.MF must be untouched
+func Rollback(base string) error {
+	var (
+		jre         = filepath.Join(base, "jre")
+		jre11       = filepath.Join(base, "jre11")
+		jre21Temp   = filepath.Join(base, "jre21_temp")
+		runBat      = filepath.Join(base, "run.bat")
+		runBatJre11 = filepath.Join(base, "run.bat_jre11")
+		tempDir     = filepath.Join(base, ".TEMP")
+		artifacts   = filepath.Join(base, ".artifacts")
+		manifest    = filepath.Join(base, "MANIFEST.MF")
+	)
+
+	// Invariant guard: snapshot ./MANIFEST.MF so we can prove it is untouched.
+	manifestBefore, manifestPresentBefore := snapshot(manifest)
+
+	// 1) Restore the Java 11 JRE backup. Skip when absent (already rolled back,
+	//    or migration never started) - never delete jre/ without a backup to
+	//    replace it with.
+	if fsops.Exists(jre11) {
+		log.Printf("restoring jre/ from jre11/")
+		if err := fsops.MoveDir(jre11, jre); err != nil {
+			return fmt.Errorf("restore jre/ from jre11/: %w", err)
+		}
+	} else {
+		log.Printf("jre11/ backup absent - skipping JRE restore")
+	}
+
+	// 2) Remove any partial jre21_temp/.
+	if fsops.Exists(jre21Temp) {
+		log.Printf("removing jre21_temp/")
+		if err := fsops.RemoveAll(jre21Temp); err != nil {
+			return fmt.Errorf("remove jre21_temp/: %w", err)
+		}
+	}
+
+	// 3) Restore the Java 11 run.bat backup.
+	if fsops.Exists(runBatJre11) {
+		log.Printf("restoring run.bat from run.bat_jre11")
+		if err := fsops.RestoreFile(runBatJre11, runBat); err != nil {
+			return fmt.Errorf("restore run.bat: %w", err)
+		}
+	}
+
+	// 4) Empty the .TEMP/ staging directory (keep the directory).
+	if fsops.Exists(tempDir) {
+		log.Printf("cleaning .TEMP/")
+		if err := fsops.CleanContents(tempDir); err != nil {
+			return fmt.Errorf("clean .TEMP/: %w", err)
+		}
+	}
+
+	// 4b) Remove the downloaded .artifacts/ (jre21.zip, run.bat, _launcher.jar).
+	//     The version mismatch is preserved (MANIFEST.MF untouched), so
+	//     softwareUpdateHandler re-downloads them if the operator retries the
+	//     upgrade (design P8 / N12 / Scenario 5; mirrors step-6 cleanup). The
+	//     rollback.exe binary lives in the app root (design step 6 lists it
+	//     separately from .artifacts/), not inside .artifacts/, so removing
+	//     .artifacts/ does not delete the executing binary.
+	if fsops.Exists(artifacts) {
+		log.Printf("removing .artifacts/")
+		if err := fsops.RemoveAll(artifacts); err != nil {
+			return fmt.Errorf("remove .artifacts/: %w", err)
+		}
+	}
+
+	// 5) Verify ./MANIFEST.MF was not touched.
+	manifestAfter, manifestPresentAfter := snapshot(manifest)
+	if manifestPresentBefore != manifestPresentAfter || manifestBefore != manifestAfter {
+		return fmt.Errorf("invariant violated: ./MANIFEST.MF changed during rollback")
+	}
+	return nil
+}
+
+// snapshot returns a stable size+modtime fingerprint of path and whether it
+// exists, used to assert ./MANIFEST.MF is untouched.
+func snapshot(path string) (fingerprint string, present bool) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return "", false
+	}
+	return fmt.Sprintf("%d:%d", fi.Size(), fi.ModTime().UnixNano()), true
+}

--- a/native/internal/upgrade/upgrade.go
+++ b/native/internal/upgrade/upgrade.go
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 // Package upgrade holds the shared logic for BOTH native upgrade executables in
 // a single file: the Java 11 -> 21 migration (T3 #809, built as migration.exe)
 // and its inverse rollback (T4 #811, built as rollback.exe). Keeping the swap

--- a/native/internal/upgrade/upgrade.go
+++ b/native/internal/upgrade/upgrade.go
@@ -106,6 +106,30 @@ func Migrate(base string) error {
 	return nil
 }
 
+// ShouldRollback reports whether a failed Migrate warrants auto-invoking
+// rollback.exe. It enforces the intent behind the design's rollback-trigger
+// table (registration-upgrade.md step 4a): roll back only while jre/ is missing
+// or partially populated — never once the JRE swap has already completed.
+//
+// The distinction matters for late-stage failures. The JRE swap (extract,
+// back up, promote) can complete fully — jre/ is now a valid Java 21 — and yet
+// Migrate still return an error from a later, non-destructive step such as the
+// lib/ reset or the run.bat copy (e.g. an antivirus lock or a transient
+// permission error). Rolling back there would delete the good Java 21 jre/ and
+// restore Java 11, discarding real progress. Because migration.exe is
+// idempotent/resumable, the correct recovery is simply to re-run it: it detects
+// major==21, skips the swap, and retries only the failed tail steps. So when
+// jre/ is already a complete Java 21, do NOT roll back.
+//
+// For every other failure (jre/ missing, partially populated, or still the
+// untouched Java 11 from an early extract failure) rollback is invoked: it
+// restores jre11/ if a backup exists and otherwise only performs the harmless
+// cleanup the design expects (restore run.bat_jre11, empty .TEMP/, remove
+// .artifacts/) — it never deletes jre/ without a backup to replace it.
+func ShouldRollback(base string) bool {
+	return jre.DetectMajor(filepath.Join(base, "jre")) != 21
+}
+
 // Rollback restores the Registration Client to its pre-migration state after a
 // failed or aborted migration (design registration-upgrade.md step 4a / issue
 // #811). It is fully idempotent (safe to run multiple times) and never touches

--- a/native/internal/upgrade/upgrade.go
+++ b/native/internal/upgrade/upgrade.go
@@ -196,3 +196,4 @@ func snapshot(path string) (fingerprint string, present bool) {
 	}
 	return fmt.Sprintf("%d:%d", fi.Size(), fi.ModTime().UnixNano()), true
 }
+


### PR DESCRIPTION
Refer Story https://github.com/mosip/registration-client/issues/807
Fixes https://github.com/mosip/registration-client/issues/811 & https://github.com/mosip/registration-client/issues/809

## Summary
Adds two native Windows executables — migration.exe and rollback.exe — that perform the Java 11 → 21 JRE swap for the upgrade-revamp feature outside the JVM. The swap deletes and replaces the very jre/ a running JVM would hold open (Windows locks in-use files), so _launcher.jar starts these binaries and exits the JVM first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Windows tooling to upgrade and roll back the bundled Java runtime.
  * Added Windows pop-up dialogs for success/error reporting, plus non-Windows console fallbacks for development builds.
* **Bug Fixes**
  * Improved upgrade reliability with resumable/idempotent migration, safe backups, and protected handling of existing state.
  * Strengthened ZIP extraction by preventing path traversal during unpacking and adding rollback invariants.
* **Documentation**
  * Documented the native migration/rollback process and build/test steps.
* **Tests**
  * Expanded migration and rollback test coverage for success, failure, and repeated-run scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->